### PR TITLE
Dev

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2024.7.4
+current_version = 2024.8.1
 commit = False
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - fix off-by-1 error in rows of efficiency-LUTs
   - remove limiting-behavior of boost-regulator
   - add residue-feature to calibration-converters
-  - bq25504 - to not cut-off output
+  - bq25504 - to not cut-off output, increase capacity to 100 uF and adapt pwr-good-voltages (close to DK)
 - ivcurve-recording: switch to rising ramp due to problems with the step in the falling configuration (high voltage & current)
 - hdf5-writer: only modify non-None elements
 - hdf5-reader: improve samplerate calculation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # History of Changes
 
+## v2024.8.1
+
+- plotting: disable creation of tick-offset 
+- cal: add si-unit
+- add `core/example/vsource_emulation.py` that processes hdf5-recordings and also generates them 
+- virtual source model
+  - fix off-by-1 error in rows of efficiency-LUTs
+  - remove limiting-behavior of boost-regulator
+  - add residue-feature to calibration-converters
+  - bq25504 - to not cut-off output
+
 ## v2024.7.4
 
 - fix two bugs in calibration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
   - remove limiting-behavior of boost-regulator
   - add residue-feature to calibration-converters
   - bq25504 - to not cut-off output, increase capacity to 100 uF and adapt pwr-good-voltages (close to DK)
-- ivcurve-recording: switch to rising ramp due to problems with the step in the falling configuration (high voltage & current)
+- ivcurve-harvesting-fixture: make 110 Hz version the new default
+- isc-voc-harvesting-fixture: give 4x more time to settle
 - hdf5-writer: only modify non-None elements
 - hdf5-reader: improve samplerate calculation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 ## v2024.8.1
 
-- plotting: disable creation of tick-offset 
+- plotting: disable creation of tick-offset
 - cal: add si-unit
-- add `core/example/vsource_emulation.py` that processes hdf5-recordings and also generates them 
+- add `shepherd_core/example/vsource_emulation.py` that processes hdf5-recordings and also generates them
+- add `shepherd_core/examples/eenv_generator.py` to create static energy environments
 - virtual source model
   - fix off-by-1 error in rows of efficiency-LUTs
   - remove limiting-behavior of boost-regulator
   - add residue-feature to calibration-converters
   - bq25504 - to not cut-off output
+- ivcurve-recording: switch to rising ramp due to problems with the step in the falling configuration (high voltage & current)
+- hdf5-writer: only modify non-None elements
+- hdf5-reader: improve samplerate calculation
 
 ## v2024.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   - remove limiting-behavior of boost-regulator
   - add residue-feature to calibration-converters
   - bq25504 - to not cut-off output, increase capacity to 100 uF and adapt pwr-good-voltages (close to DK)
+- harvester model
+  - fix voc-harvesting
+  - improve windowing setting for ingested ivcurve
+  - port behavior from PRU
+  - port behavior from PRU
 - ivcurve-harvesting-fixture: make 110 Hz version the new default
 - isc-voc-harvesting-fixture: give 4x more time to settle
 - hdf5-writer: only modify non-None elements

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ coverage report
 ```shell
 pipenv shell
 
-bump2version --allow-dirty --new-version 2024.7.4 patch
+bump2version --allow-dirty --new-version 2024.8.1 patch
 # ⤷ format: year.month.patch_release
 
 pre-commit run --all-files

--- a/shepherd_core/examples/eenv_generator.py
+++ b/shepherd_core/examples/eenv_generator.py
@@ -1,6 +1,5 @@
-"""Create a set of static artificial energy environments.
+"""Create a set of static artificial energy environments."""
 
-"""
 from itertools import product
 from pathlib import Path
 
@@ -8,8 +7,8 @@ import numpy as np
 from tqdm import trange
 
 from shepherd_core import Reader as ShpReader
-from shepherd_core import logger
 from shepherd_core import Writer as ShpWriter
+from shepherd_core import logger
 
 # Config
 voltages_V = [4.0, 2.0]

--- a/shepherd_core/examples/eenv_generator.py
+++ b/shepherd_core/examples/eenv_generator.py
@@ -1,0 +1,44 @@
+"""Create a set of static artificial energy environments.
+
+"""
+from itertools import product
+from pathlib import Path
+
+import numpy as np
+from tqdm import trange
+
+from shepherd_core import Reader as ShpReader
+from shepherd_core import logger
+from shepherd_core import Writer as ShpWriter
+
+# Config
+voltages_V = [4.0, 2.0]
+currents_A = [2e-3, 1e-3]
+duration_s = 10
+repetitions = 1
+
+path_here = Path(__file__).parent.absolute()
+
+for _v, _c in product(voltages_V, currents_A):
+    v_str = f"{round(_v * 1000)}mV"
+    c_str = f"{round(_c * 1000)}mA"
+    t_str = f"{round(duration_s * repetitions)}s"
+    name = f"eenv_static_{v_str}_{c_str}_{t_str}"
+    file_path = path_here / f"{name}.h5"
+
+    if file_path.exists():
+        logger.info("File exists, will skip: %s", file_path.name)
+    else:
+        with ShpWriter(file_path) as file:
+            file.store_hostname("artificial")
+            # values in SI units
+            timestamp_vector = np.arange(0.0, duration_s, file.sample_interval_ns / 1e9)
+            voltage_vector = np.linspace(_v, _v, int(file.samplerate_sps * duration_s))
+            current_vector = np.linspace(_c, _c, int(file.samplerate_sps * duration_s))
+
+            for idx in trange(repetitions, desc="generate"):
+                timestamps = idx * duration_s + timestamp_vector
+                file.append_iv_data_si(timestamps, voltage_vector, current_vector)
+
+    with ShpReader(file_path) as file:
+        file.save_metadata()

--- a/shepherd_core/examples/vharvester_simulation.py
+++ b/shepherd_core/examples/vharvester_simulation.py
@@ -6,9 +6,12 @@
 
 """
 
+from contextlib import ExitStack
 from pathlib import Path
 
+from shepherd_core import CalibrationHarvester
 from shepherd_core import Reader
+from shepherd_core import Writer
 from shepherd_core.data_models import VirtualHarvesterConfig
 from shepherd_core.data_models.content.virtual_harvester import HarvesterPRUConfig
 from shepherd_core.vsource import VirtualHarvesterModel
@@ -32,6 +35,8 @@ hrv_list = [
     "mppt_opt",
 ]
 
+save_files: bool = True
+
 # convert IVonne to IVCurve
 if not file_ivcurve.exists():
     with ivonne.Reader(file_ivonne) as db:
@@ -45,7 +50,7 @@ with Reader(file_ivcurve, verbose=False) as file:
         I_in_max = max(I_in_max, _i.max())
     print(
         f"Input-file: \n"
-        f"\tE_in = {file.energy() * 1e3:.3f} mWs\n"
+        f"\tE_in = {file.energy() * 1e3:.3f} mWs (not representative)\n"
         f"\tI_in_max = {I_in_max * 1e3:.3f} mA\n"
         f"\twindow_size = {window_size} n\n",
     )
@@ -53,21 +58,37 @@ with Reader(file_ivcurve, verbose=False) as file:
 # Simulation
 for hrv_name in hrv_list:
     E_out_Ws = 0.0
+    _cal = CalibrationHarvester()
+    if save_files:
+        stack = ExitStack()
+        file_output = file_ivcurve.with_stem(file_ivcurve.stem + "_" + hrv_name)
+        fh_output = Writer(
+            file_output, cal_data=_cal, mode="harvester", verbose=False, force_overwrite=True
+        )
+        stack.enter_context(fh_output)
+        fh_output.store_hostname("hrv_sim_" + hrv_name)
+
     with Reader(file_ivcurve, verbose=False) as file:
         hrv_config = VirtualHarvesterConfig(name=hrv_name)
         hrv_pru = HarvesterPRUConfig.from_vhrv(
             hrv_config,
             for_emu=True,
             dtype_in=file.get_datatype(),
-            window_size=file.get_window_samples(),
+            window_size=4 * file.get_window_samples(),
         )
         hrv = VirtualHarvesterModel(hrv_pru)
         for _t, _v, _i in file.read_buffers():
+            # TODO: _t should be handed to new file without conversions
             length = max(_v.size, _i.size)
             for _n in range(length):
                 _v[_n], _i[_n] = hrv.ivcurve_sample(
                     _voltage_uV=_v[_n] * 10**6, _current_nA=_i[_n] * 10**9
                 )
             E_out_Ws += (_v * _i).sum() * 1e-15 * file.sample_interval_s
-
+            if save_files:
+                fh_output.append_iv_data_si(_t, _v / 1e6, _i / 1e9)
+        if save_files:
+            stack.close()
+            with Reader(file_output) as fh_output:
+                fh_output.save_metadata()
         print(f"E_out = {E_out_Ws * 1e3:.3f} mWs -> {hrv_name}")

--- a/shepherd_core/examples/vharvester_simulation.py
+++ b/shepherd_core/examples/vharvester_simulation.py
@@ -61,7 +61,9 @@ for hrv_name in hrv_list:
     _cal = CalibrationHarvester()
     if save_files:
         stack = ExitStack()
-        file_output = file_ivcurve.with_stem(file_ivcurve.stem + "_" + hrv_name)
+        file_output = file_ivcurve.with_name(
+            file_ivcurve.stem + "_" + hrv_name + file_ivcurve.suffix
+        )
         fh_output = Writer(
             file_output, cal_data=_cal, mode="harvester", verbose=False, force_overwrite=True
         )

--- a/shepherd_core/examples/vsource_emulation.py
+++ b/shepherd_core/examples/vsource_emulation.py
@@ -1,0 +1,80 @@
+"""Demonstrate behavior of Virtual Source Algorithms.
+
+The emulation recreates an observer-cape, the virtual Source and a virtual target
+- input = hdf5-file with a harvest-recording
+- output = hdf5-file
+- config is currently hardcoded, but it could be an emulation-task, TODO: `shepherd-data emulate config.yaml`
+- target is currently a simple resistor
+
+The output file can be analyzed and plotted with shepherds tool suite.
+"""
+
+from pathlib import Path
+
+import numpy as np
+from tqdm import tqdm
+
+from shepherd_core import CalibrationEmulator, Reader, Writer
+from shepherd_core.data_models import VirtualSourceConfig, VirtualHarvesterConfig
+from shepherd_core.vsource import VirtualSourceModel
+
+# config simulation
+file_input = Path(__file__).parent.parent.parent / "hrv_ivcurve.h5"
+file_output = Path(__file__).parent / "emu_ivcurve.h5"
+
+src_list = ["BQ25570"] #"BQ25504"
+
+#I_mcu_sleep_A = 3e-3
+#I_mcu_active_A = 3e-3
+R_Ohm = 1000
+
+for vs_name in src_list:
+
+    cal_emu = CalibrationEmulator()
+    src_config = VirtualSourceConfig(
+        inherit_from=vs_name,
+        C_output_uF=0,
+        V_output_mV=3000,
+        V_intermediate_init_mV=3600,
+        harvester=VirtualHarvesterConfig(name="mppt_bq_solar"),
+        V_buck_drop_mV=0,
+    )
+
+    with Reader(file_input, verbose=False) as f_inp, Writer(file_output, cal_data=cal_emu, mode="emulator", verbose=False) as f_out:
+
+        window_size = f_inp.get_window_samples()
+        f_out.store_hostname("simulation")
+        f_out.store_config(src_config.model_dump())
+        src = VirtualSourceModel(src_config, cal_emu, log_intermediate=False, window_size=window_size)
+
+        I_out_nA = 0
+
+        for _t, _V_inp, _I_inp in tqdm(f_inp.read_buffers(), total=f_inp.buffers_n):
+
+            V_out = np.empty(_V_inp.shape)
+            I_out = np.empty(_I_inp.shape)
+
+            for _iter in range(len(_t)):
+
+                V_out_uV = src.iterate_sampling(
+                    V_inp_uV=_V_inp[_iter] * 10**6,
+                    I_inp_nA=_I_inp[_iter] * 10**9,
+                    I_out_nA=I_out_nA,
+                )
+                I_out_nA = 1e3 * V_out_uV / R_Ohm
+
+                V_out[_iter] = V_out_uV / 1e6
+                I_out[_iter] = I_out_nA / 1e9
+
+                src.cnv.get_I_mod_out_nA()
+
+            f_out.append_iv_data_si(_t, V_out, I_out)
+
+            # listen to power-good signal
+            """
+            if src.cnv.get_power_good():
+                I_out_nA = int(I_mcu_active_A * 10 ** 9)
+                N_good += 1
+            else:
+                I_out_nA = int(I_mcu_sleep_A * 10 ** 9)
+            """

--- a/shepherd_core/examples/vsource_emulation.py
+++ b/shepherd_core/examples/vsource_emulation.py
@@ -32,7 +32,7 @@ I_mcu_active_A = 3e-3
 R_Ohm = 1000
 
 for vs_name in src_list:
-    file_output = file_input.with_stem(file_input.stem + "_emu_" + vs_name)
+    file_output = file_input.with_name(file_input.stem + "_emu_" + vs_name + file_input.suffix)
 
     cal_emu = CalibrationEmulator()
     src_config = VirtualSourceConfig(

--- a/shepherd_core/examples/vsource_emulation.py
+++ b/shepherd_core/examples/vsource_emulation.py
@@ -3,33 +3,36 @@
 The emulation recreates an observer-cape, the virtual Source and a virtual target
 - input = hdf5-file with a harvest-recording
 - output = hdf5-file
-- config is currently hardcoded, but it could be an emulation-task, TODO: `shepherd-data emulate config.yaml`
+- config is currently hardcoded, but it could be an emulation-task
 - target is currently a simple resistor
 
 The output file can be analyzed and plotted with shepherds tool suite.
 """
+# TODO: `shepherd-data emulate config.yaml`
 
 from pathlib import Path
 
 import numpy as np
 from tqdm import tqdm
 
-from shepherd_core import CalibrationEmulator, Reader, Writer
-from shepherd_core.data_models import VirtualSourceConfig, VirtualHarvesterConfig
+from shepherd_core import CalibrationEmulator
+from shepherd_core import Reader
+from shepherd_core import Writer
+from shepherd_core.data_models import VirtualHarvesterConfig
+from shepherd_core.data_models import VirtualSourceConfig
 from shepherd_core.vsource import VirtualSourceModel
 
 # config simulation
 file_input = Path(__file__).parent.parent.parent / "hrv_ivcurve.h5"
 file_output = Path(__file__).parent / "emu_ivcurve.h5"
 
-src_list = ["BQ25570"] #"BQ25504"
+src_list = ["BQ25570"]  # "BQ25504"
 
-#I_mcu_sleep_A = 3e-3
-#I_mcu_active_A = 3e-3
+I_mcu_sleep_A = 3e-3
+I_mcu_active_A = 3e-3
 R_Ohm = 1000
 
 for vs_name in src_list:
-
     cal_emu = CalibrationEmulator()
     src_config = VirtualSourceConfig(
         inherit_from=vs_name,
@@ -40,22 +43,23 @@ for vs_name in src_list:
         V_buck_drop_mV=0,
     )
 
-    with Reader(file_input, verbose=False) as f_inp, Writer(file_output, cal_data=cal_emu, mode="emulator", verbose=False) as f_out:
-
+    with Reader(file_input, verbose=False) as f_inp, Writer(
+        file_output, cal_data=cal_emu, mode="emulator", verbose=False
+    ) as f_out:
         window_size = f_inp.get_window_samples()
         f_out.store_hostname("simulation")
         f_out.store_config(src_config.model_dump())
-        src = VirtualSourceModel(src_config, cal_emu, log_intermediate=False, window_size=window_size)
+        src = VirtualSourceModel(
+            src_config, cal_emu, log_intermediate=False, window_size=window_size
+        )
 
         I_out_nA = 0
 
         for _t, _V_inp, _I_inp in tqdm(f_inp.read_buffers(), total=f_inp.buffers_n):
-
             V_out = np.empty(_V_inp.shape)
             I_out = np.empty(_I_inp.shape)
 
             for _iter in range(len(_t)):
-
                 V_out_uV = src.iterate_sampling(
                     V_inp_uV=_V_inp[_iter] * 10**6,
                     I_inp_nA=_I_inp[_iter] * 10**9,
@@ -66,7 +70,7 @@ for vs_name in src_list:
                 V_out[_iter] = V_out_uV / 1e6
                 I_out[_iter] = I_out_nA / 1e9
 
-                src.cnv.get_I_mod_out_nA()
+                # TODO: src.cnv.get_I_mod_out_nA() has more internal drains
 
             f_out.append_iv_data_si(_t, V_out, I_out)
 

--- a/shepherd_core/examples/vsource_emulation.py
+++ b/shepherd_core/examples/vsource_emulation.py
@@ -23,50 +23,30 @@ from shepherd_core.data_models import VirtualSourceConfig
 from shepherd_core.vsource import VirtualSourceModel
 
 # config simulation
-file_input = Path(__file__).parent.parent.parent / "hrv_opt.h5"
-file_output = Path(__file__).parent / "emu_opt04.h5"
+file_input = Path(__file__).parent / "jogging_ivcurve.h5"
 
-src_list = ["BQ25504"]  # "BQ25504"
+src_list = ["BQ25504"]
 
 I_mcu_sleep_A = 3e-3
 I_mcu_active_A = 3e-3
 R_Ohm = 1000
 
 for vs_name in src_list:
+    file_output = file_input.with_stem(file_input.stem + "_emu_" + vs_name)
+
     cal_emu = CalibrationEmulator()
     src_config = VirtualSourceConfig(
         inherit_from=vs_name,
-        C_output_uF=0,
-        # V_output_mV=3000,
-        V_intermediate_init_mV=1000,
+        V_intermediate_init_mV=3000,
         harvester=VirtualHarvesterConfig(name="mppt_bq_solar"),
-        V_buck_drop_mV=0,
-        # C_intermediate_uF=100,
-        V_intermediate_disable_threshold_mV=0,
-        LUT_input_efficiency=[
-          # <8uA  8uA   16uA  32uA  64uA  128uA 256uA 512uA 1mA   2mA   4mA   >8mA
-          [0.01, 0.01, 0.02, 0.05, 0.10, 0.15, 0.15, 0.20, 0.25, 0.30, 0.30, 0.35],  # < 128 mV
-          [0.10, 0.20, 0.30, 0.40, 0.50, 0.55, 0.56, 0.57, 0.58, 0.59, 0.60, 0.61],  # > 128 mV, ~200
-          [0.20, 0.40, 0.50, 0.60, 0.65, 0.66, 0.67, 0.68, 0.69, 0.70, 0.71, 0.72],  # > 256 mV, ~320
-          [0.35, 0.55, 0.65, 0.71, 0.73, 0.74, 0.75, 0.75, 0.76, 0.77, 0.77, 0.78],  # > 384 mV, ~450
-          [0.45, 0.65, 0.70, 0.73, 0.75, 0.77, 0.78, 0.79, 0.80, 0.81, 0.81, 0.82],  # > 512 mV, ~570
-          [0.50, 0.70, 0.74, 0.76, 0.78, 0.79, 0.80, 0.81, 0.82, 0.83, 0.83, 0.84],  # > 640 mV
-          [0.52, 0.73, 0.76, 0.78, 0.80, 0.81, 0.82, 0.83, 0.84, 0.85, 0.85, 0.86],  # > 768 mV
-          [0.53, 0.75, 0.77, 0.79, 0.81, 0.82, 0.83, 0.84, 0.85, 0.86, 0.86, 0.87],  # > 896 mV
-          [0.55, 0.77, 0.78, 0.80, 0.82, 0.83, 0.85, 0.86, 0.87, 0.87, 0.87, 0.88],  # > 1024 mV
-          [0.56, 0.78, 0.79, 0.81, 0.83, 0.85, 0.87, 0.88, 0.88, 0.88, 0.88, 0.89],  # > 1152 mV
-          [0.58, 0.79, 0.80, 0.82, 0.84, 0.86, 0.88, 0.89, 0.89, 0.89, 0.89, 0.90],  # > 1280 mV
-          [0.60, 0.80, 0.81, 0.83, 0.85, 0.87, 0.89, 0.90, 0.90, 0.90, 0.90, 0.90],  # > 1408 mV
-        ]
-        # input-array[12][12] depending on array[inp_voltage][log(inp_current)],
-        # influence of cap-voltage is not implemented
+        C_intermediate_uF=50,
     )
 
     with Reader(file_input, verbose=False) as f_inp, Writer(
         file_output, cal_data=cal_emu, mode="emulator", verbose=False
     ) as f_out:
         window_size = f_inp.get_window_samples()
-        f_out.store_hostname("simulation")
+        f_out.store_hostname("emu_sim_" + vs_name)
         f_out.store_config(src_config.model_dump())
         src = VirtualSourceModel(
             src_config, cal_emu, log_intermediate=False, window_size=window_size
@@ -101,3 +81,6 @@ for vs_name in src_list:
             else:
                 I_out_nA = int(I_mcu_sleep_A * 10 ** 9)
             """
+
+    with Reader(file_output, verbose=False) as f_out:
+        f_out.save_metadata()

--- a/shepherd_core/examples/vsource_emulation.py
+++ b/shepherd_core/examples/vsource_emulation.py
@@ -23,10 +23,10 @@ from shepherd_core.data_models import VirtualSourceConfig
 from shepherd_core.vsource import VirtualSourceModel
 
 # config simulation
-file_input = Path(__file__).parent.parent.parent / "hrv_ivcurve.h5"
-file_output = Path(__file__).parent / "emu_ivcurve.h5"
+file_input = Path(__file__).parent.parent.parent / "hrv_opt.h5"
+file_output = Path(__file__).parent / "emu_opt04.h5"
 
-src_list = ["BQ25570"]  # "BQ25504"
+src_list = ["BQ25504"]  # "BQ25504"
 
 I_mcu_sleep_A = 3e-3
 I_mcu_active_A = 3e-3
@@ -37,10 +37,12 @@ for vs_name in src_list:
     src_config = VirtualSourceConfig(
         inherit_from=vs_name,
         C_output_uF=0,
-        V_output_mV=3000,
+        #V_output_mV=3000,
         V_intermediate_init_mV=3600,
         harvester=VirtualHarvesterConfig(name="mppt_bq_solar"),
         V_buck_drop_mV=0,
+        #C_intermediate_uF=100,
+        V_intermediate_disable_threshold_mV=0,
     )
 
     with Reader(file_input, verbose=False) as f_inp, Writer(

--- a/shepherd_core/examples/vsource_emulation.py
+++ b/shepherd_core/examples/vsource_emulation.py
@@ -37,12 +37,29 @@ for vs_name in src_list:
     src_config = VirtualSourceConfig(
         inherit_from=vs_name,
         C_output_uF=0,
-        #V_output_mV=3000,
-        V_intermediate_init_mV=3600,
+        # V_output_mV=3000,
+        V_intermediate_init_mV=1000,
         harvester=VirtualHarvesterConfig(name="mppt_bq_solar"),
         V_buck_drop_mV=0,
-        #C_intermediate_uF=100,
+        # C_intermediate_uF=100,
         V_intermediate_disable_threshold_mV=0,
+        LUT_input_efficiency=[
+          # <8uA  8uA   16uA  32uA  64uA  128uA 256uA 512uA 1mA   2mA   4mA   >8mA
+          [0.01, 0.01, 0.02, 0.05, 0.10, 0.15, 0.15, 0.20, 0.25, 0.30, 0.30, 0.35],  # < 128 mV
+          [0.10, 0.20, 0.30, 0.40, 0.50, 0.55, 0.56, 0.57, 0.58, 0.59, 0.60, 0.61],  # > 128 mV, ~200
+          [0.20, 0.40, 0.50, 0.60, 0.65, 0.66, 0.67, 0.68, 0.69, 0.70, 0.71, 0.72],  # > 256 mV, ~320
+          [0.35, 0.55, 0.65, 0.71, 0.73, 0.74, 0.75, 0.75, 0.76, 0.77, 0.77, 0.78],  # > 384 mV, ~450
+          [0.45, 0.65, 0.70, 0.73, 0.75, 0.77, 0.78, 0.79, 0.80, 0.81, 0.81, 0.82],  # > 512 mV, ~570
+          [0.50, 0.70, 0.74, 0.76, 0.78, 0.79, 0.80, 0.81, 0.82, 0.83, 0.83, 0.84],  # > 640 mV
+          [0.52, 0.73, 0.76, 0.78, 0.80, 0.81, 0.82, 0.83, 0.84, 0.85, 0.85, 0.86],  # > 768 mV
+          [0.53, 0.75, 0.77, 0.79, 0.81, 0.82, 0.83, 0.84, 0.85, 0.86, 0.86, 0.87],  # > 896 mV
+          [0.55, 0.77, 0.78, 0.80, 0.82, 0.83, 0.85, 0.86, 0.87, 0.87, 0.87, 0.88],  # > 1024 mV
+          [0.56, 0.78, 0.79, 0.81, 0.83, 0.85, 0.87, 0.88, 0.88, 0.88, 0.88, 0.89],  # > 1152 mV
+          [0.58, 0.79, 0.80, 0.82, 0.84, 0.86, 0.88, 0.89, 0.89, 0.89, 0.89, 0.90],  # > 1280 mV
+          [0.60, 0.80, 0.81, 0.83, 0.85, 0.87, 0.89, 0.90, 0.90, 0.90, 0.90, 0.90],  # > 1408 mV
+        ]
+        # input-array[12][12] depending on array[inp_voltage][log(inp_current)],
+        # influence of cap-voltage is not implemented
     )
 
     with Reader(file_input, verbose=False) as f_inp, Writer(

--- a/shepherd_core/shepherd_core/data_models/base/calibration.py
+++ b/shepherd_core/shepherd_core/data_models/base/calibration.py
@@ -82,11 +82,7 @@ class CalibrationPair(ShpModel):
         """Probe linear function to determine scaling values."""
         offset = fn(0, limited=False)
         gain_inv = fn(1.0, limited=False) - offset
-        return cls(
-            gain=1.0 / float(gain_inv),
-            offset=-float(offset) / gain_inv,
-            unit=unit
-        )
+        return cls(gain=1.0 / float(gain_inv), offset=-float(offset) / gain_inv, unit=unit)
 
 
 cal_hrv_legacy = {  # legacy translator

--- a/shepherd_core/shepherd_core/data_models/base/calibration.py
+++ b/shepherd_core/shepherd_core/data_models/base/calibration.py
@@ -51,7 +51,7 @@ class CalibrationPair(ShpModel):
 
     gain: PositiveFloat
     offset: float = 0
-    # TODO: add unit
+    unit: Optional[str]  # TODO: add units when used
 
     def raw_to_si(self, values_raw: Calc_t, *, allow_negative: bool = True) -> Calc_t:
         """Convert between physical units and raw unsigned integers."""
@@ -78,13 +78,14 @@ class CalibrationPair(ShpModel):
         return values_raw
 
     @classmethod
-    def from_fn(cls, fn: Callable) -> Self:
+    def from_fn(cls, fn: Callable, unit: Optional[str]) -> Self:
         """Probe linear function to determine scaling values."""
         offset = fn(0, limited=False)
         gain_inv = fn(1.0, limited=False) - offset
         return cls(
             gain=1.0 / float(gain_inv),
             offset=-float(offset) / gain_inv,
+            unit=unit
         )
 
 

--- a/shepherd_core/shepherd_core/data_models/base/calibration.py
+++ b/shepherd_core/shepherd_core/data_models/base/calibration.py
@@ -51,7 +51,7 @@ class CalibrationPair(ShpModel):
 
     gain: PositiveFloat
     offset: float = 0
-    unit: Optional[str]  # TODO: add units when used
+    unit: Optional[str] = None  # TODO: add units when used
 
     def raw_to_si(self, values_raw: Calc_t, *, allow_negative: bool = True) -> Calc_t:
         """Convert between physical units and raw unsigned integers."""
@@ -78,7 +78,7 @@ class CalibrationPair(ShpModel):
         return values_raw
 
     @classmethod
-    def from_fn(cls, fn: Callable, unit: Optional[str]) -> Self:
+    def from_fn(cls, fn: Callable, unit: Optional[str] = None) -> Self:
         """Probe linear function to determine scaling values."""
         offset = fn(0, limited=False)
         gain_inv = fn(1.0, limited=False) - offset

--- a/shepherd_core/shepherd_core/data_models/base/calibration.py
+++ b/shepherd_core/shepherd_core/data_models/base/calibration.py
@@ -96,10 +96,10 @@ cal_hrv_legacy = {  # legacy translator
 class CalibrationHarvester(ShpModel):
     """Container for all calibration-pairs for that device."""
 
-    dac_V_Hrv: CalibrationPair = CalibrationPair.from_fn(dac_voltage_to_raw)
-    dac_V_Sim: CalibrationPair = CalibrationPair.from_fn(dac_voltage_to_raw)
-    adc_V_Sense: CalibrationPair = CalibrationPair.from_fn(adc_voltage_to_raw)
-    adc_C_Hrv: CalibrationPair = CalibrationPair.from_fn(adc_current_to_raw)
+    dac_V_Hrv: CalibrationPair = CalibrationPair.from_fn(dac_voltage_to_raw, unit="V")
+    dac_V_Sim: CalibrationPair = CalibrationPair.from_fn(dac_voltage_to_raw, unit="V")
+    adc_V_Sense: CalibrationPair = CalibrationPair.from_fn(adc_voltage_to_raw, unit="V")
+    adc_C_Hrv: CalibrationPair = CalibrationPair.from_fn(adc_current_to_raw, unit="A")
 
     def export_for_sysfs(self) -> dict:
         """Convert and write the essential data.
@@ -140,10 +140,10 @@ class CalibrationEmulator(ShpModel):
     Differentiates between both target-ports A/B.
     """
 
-    dac_V_A: CalibrationPair = CalibrationPair.from_fn(dac_voltage_to_raw)
-    dac_V_B: CalibrationPair = CalibrationPair.from_fn(dac_voltage_to_raw)
-    adc_C_A: CalibrationPair = CalibrationPair.from_fn(adc_current_to_raw)
-    adc_C_B: CalibrationPair = CalibrationPair.from_fn(adc_current_to_raw)
+    dac_V_A: CalibrationPair = CalibrationPair.from_fn(dac_voltage_to_raw, unit="V")
+    dac_V_B: CalibrationPair = CalibrationPair.from_fn(dac_voltage_to_raw, unit="V")
+    adc_C_A: CalibrationPair = CalibrationPair.from_fn(adc_current_to_raw, unit="A")
+    adc_C_B: CalibrationPair = CalibrationPair.from_fn(adc_current_to_raw, unit="A")
 
     def export_for_sysfs(self) -> dict:
         """Convert and write the essential data.
@@ -257,11 +257,11 @@ class CalibrationCape(ShpModel):
 class CalibrationSeries(ShpModel):
     """Cal-Data for a typical recording of a testbed experiment."""
 
-    voltage: CalibrationPair = CalibrationPair(gain=3 * 1e-9)
+    voltage: CalibrationPair = CalibrationPair(gain=3 * 1e-9, unit="V")
     # ⤷ default allows 0 - 12 V in 3 nV-Steps
-    current: CalibrationPair = CalibrationPair(gain=250 * 1e-12)
+    current: CalibrationPair = CalibrationPair(gain=250 * 1e-12, unit="A")
     # ⤷ default allows 0 - 1 A in 250 pA - Steps
-    time: CalibrationPair = CalibrationPair(gain=1e-9)
+    time: CalibrationPair = CalibrationPair(gain=1e-9, unit="s")
     # ⤷ default = nanoseconds
 
     @classmethod

--- a/shepherd_core/shepherd_core/data_models/base/calibration.py
+++ b/shepherd_core/shepherd_core/data_models/base/calibration.py
@@ -230,10 +230,11 @@ class CalibrationCape(ShpModel):
 
         """
         dv = cls().model_dump(include={"harvester", "emulator"})
-        lw = list(dict_generator(dv))
-        values = struct.unpack(">" + len(lw) * "d", data)
+        lw1 = list(dict_generator(dv))
+        lw2 = [elem for elem in lw1 if isinstance(elem[-1], float)]
+        values = struct.unpack(">" + len(lw2) * "d", data)
         # ⤷ X => double float, big endian
-        for _i, walk in enumerate(lw):
+        for _i, walk in enumerate(lw2):
             # hardcoded fixed depth ... bad but easy
             dv[walk[0]][walk[1]][walk[2]] = float(values[_i])
         dv["cape"] = cape
@@ -249,8 +250,8 @@ class CalibrationCape(ShpModel):
 
         """
         lw = list(dict_generator(self.model_dump(include={"harvester", "emulator"})))
-        values = [walk[-1] for walk in lw]
-        return struct.pack(">" + len(lw) * "d", *values)
+        values = [walk[-1] for walk in lw if isinstance(walk[-1], float)]
+        return struct.pack(">" + len(values) * "d", *values)
 
 
 class CalibrationSeries(ShpModel):

--- a/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
@@ -155,8 +155,10 @@ class VirtualHarvesterConfig(ContentModel, title="Config for the Harvester"):
     ) -> int:
         if not for_emu:
             # TODO: should be named 'for_ivcurve_recording'
+            # TODO: add extra variable to distinguish step_count
+            #       and window_size (currently mixed together)
             # only used by ivcurve algo (in ADC-Mode)
-           return self.samples_n
+            return self.samples_n
 
         if dtype_in is None:
             dtype_in = self.get_datatype()

--- a/shepherd_core/shepherd_core/data_models/content/virtual_harvester_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_harvester_fixture.yaml
@@ -19,14 +19,14 @@
     id: 1010
     name: ivcurve
     description: Postpone harvesting by sampling ivcurves (voltage stepped as sawtooth-wave)
-    comment: ~200 Hz
+    comment: ~110 Hz, Between 50 & 60 Hz line-frequency to avoid standing waves
     inherit_from: neutral
     algorithm: ivcurve
-    samples_n: 250
+    samples_n: 909
     voltage_min_mV: 0
     voltage_max_mV: 5000
-    wait_cycles: 1  # results in 200 Hz (= 100kHz /(2*250))
-    rising: true # NOTE: falling ramp shows errors during step (high voltage and still higher current)
+    wait_cycles: 0
+    rising: false # downward sawtooth seems to have advantages for solar cells
     # todo: also add switch for sawtooth- vs triangle-wave?
     # todo: could also include a version with dynamic upper-boundary, varied if voc is reached very early
 
@@ -34,6 +34,12 @@
   parameters:
     id: 1011
     name: ivcurves  # synonym
+    inherit_from: ivcurve
+
+- datatype: VirtualHarvesterConfig
+  parameters:
+    id: 1013
+    name: iv110 # synonym
     inherit_from: ivcurve
 
 - datatype: VirtualHarvesterConfig
@@ -47,21 +53,12 @@
 
 - datatype: VirtualHarvesterConfig
   parameters:
-    id: 1013
-    name: iv110
-    comment: Between 50 & 60 Hz line-frequency to avoid standing waves
-    inherit_from: ivcurve
-    samples_n: 909
-    wait_cycles: 0
-
-- datatype: VirtualHarvesterConfig
-  parameters:
     id: 1020
     name: isc_voc
     description: Postpone harvesting by sampling short circuit current & open circuit voltage
     inherit_from: neutral
     algorithm: isc_voc
-    wait_cycles: 1  # results in 25 kHz (isc, wait, voc, wait)
+    wait_cycles: 4  # results in 10 kHz (isc, wait, voc, wait)
 
 - datatype: VirtualHarvesterConfig
   parameters:

--- a/shepherd_core/shepherd_core/data_models/content/virtual_harvester_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_harvester_fixture.yaml
@@ -26,7 +26,7 @@
     voltage_min_mV: 0
     voltage_max_mV: 5000
     wait_cycles: 1  # results in 200 Hz (= 100kHz /(2*250))
-    rising: false # downward sawtooth seems to have advantages for solar cells
+    rising: true # NOTE: falling ramp shows errors during step (high voltage and still higher current)
     # todo: also add switch for sawtooth- vs triangle-wave?
     # todo: could also include a version with dynamic upper-boundary, varied if voc is reached very early
 

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -320,8 +320,8 @@ class ConverterPRUConfig(ShpModel):
             V_buck_drop_uV=round(data.V_buck_drop_mV * 1e3),
             # LUTs
             LUT_input_V_min_log2_uV=data.LUT_input_V_min_log2_uV,
-            LUT_input_I_min_log2_nA=data.LUT_input_I_min_log2_nA - 1,  # sub-1 due to later log2() operation
-            LUT_output_I_min_log2_nA=data.LUT_output_I_min_log2_nA - 1,  # sub-1 due to later log2() operation
+            LUT_input_I_min_log2_nA=data.LUT_input_I_min_log2_nA - 1,  # sub-1 due to later log2-op
+            LUT_output_I_min_log2_nA=data.LUT_output_I_min_log2_nA - 1,  # sub-1 due to later log2
             LUT_inp_efficiency_n8=[
                 [min(255, round(256 * ival)) for ival in il] for il in data.LUT_input_efficiency
             ],

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -76,6 +76,8 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
     # final (always last) stage to compensate undetectable current spikes
     # when enabling power for target
     C_output_uF: Annotated[float, Field(ge=0, le=4.29e6)] = 1.0
+    # TODO: C_output is handled internally as delta-V, but should be a I_transient
+    #       that makes it visible in simulation as additional i_out_drain
 
     # Extra
     V_output_log_gpio_threshold_mV: Annotated[float, Field(ge=0, le=4.29e6)] = 1_400

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -95,7 +95,7 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
     # influence of cap-voltage is not implemented
     LUT_input_V_min_log2_uV: Annotated[int, Field(ge=0, le=20)] = 0
     # ⤷ 2^7 = 128 uV -> LUT[0][:] is for inputs < 128 uV
-    LUT_input_I_min_log2_nA: Annotated[int, Field(ge=0, le=20)] = 0
+    LUT_input_I_min_log2_nA: Annotated[int, Field(ge=1, le=20)] = 0
     # ⤷ 2^8 = 256 nA -> LUT[:][0] is for inputs < 256 nA
 
     # Buck Converter
@@ -105,7 +105,7 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
 
     LUT_output_efficiency: LUT1D = 12 * [1.00]
     # ⤷ array[12] depending on output_current
-    LUT_output_I_min_log2_nA: Annotated[int, Field(ge=0, le=20)] = 0
+    LUT_output_I_min_log2_nA: Annotated[int, Field(ge=1, le=20)] = 0
     # ⤷ 2^8 = 256 nA -> LUT[0] is for inputs < 256 nA, see notes on LUT_input for explanation
 
     @model_validator(mode="before")
@@ -320,8 +320,8 @@ class ConverterPRUConfig(ShpModel):
             V_buck_drop_uV=round(data.V_buck_drop_mV * 1e3),
             # LUTs
             LUT_input_V_min_log2_uV=data.LUT_input_V_min_log2_uV,
-            LUT_input_I_min_log2_nA=data.LUT_input_I_min_log2_nA,
-            LUT_output_I_min_log2_nA=data.LUT_output_I_min_log2_nA,
+            LUT_input_I_min_log2_nA=data.LUT_input_I_min_log2_nA - 1,  # sub-1 due to later log2() operation
+            LUT_output_I_min_log2_nA=data.LUT_output_I_min_log2_nA - 1,  # sub-1 due to later log2() operation
             LUT_inp_efficiency_n8=[
                 [min(255, round(256 * ival)) for ival in il] for il in data.LUT_input_efficiency
             ],

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -95,7 +95,7 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
     # influence of cap-voltage is not implemented
     LUT_input_V_min_log2_uV: Annotated[int, Field(ge=0, le=20)] = 0
     # ⤷ 2^7 = 128 uV -> LUT[0][:] is for inputs < 128 uV
-    LUT_input_I_min_log2_nA: Annotated[int, Field(ge=1, le=20)] = 0
+    LUT_input_I_min_log2_nA: Annotated[int, Field(ge=1, le=20)] = 1
     # ⤷ 2^8 = 256 nA -> LUT[:][0] is for inputs < 256 nA
 
     # Buck Converter
@@ -105,7 +105,7 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
 
     LUT_output_efficiency: LUT1D = 12 * [1.00]
     # ⤷ array[12] depending on output_current
-    LUT_output_I_min_log2_nA: Annotated[int, Field(ge=1, le=20)] = 0
+    LUT_output_I_min_log2_nA: Annotated[int, Field(ge=1, le=20)] = 1
     # ⤷ 2^8 = 256 nA -> LUT[0] is for inputs < 256 nA, see notes on LUT_input for explanation
 
     @model_validator(mode="before")

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source_fixture.yaml
@@ -58,14 +58,14 @@
       [ 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00 ],
     ] # input-array[12][12] depending on array[inp_voltage][log(inp_current)], influence of cap-voltage is not implemented
     LUT_input_V_min_log2_uV: 0 # 2^7 = 128 uV -> array[0] is for inputs < 128 uV
-    LUT_input_I_min_log2_nA: 0 # 2^8 = 256 nA -> array[0] is for inputs < 256 nA
+    LUT_input_I_min_log2_nA: 1 # 2^8 = 256 nA -> array[0] is for inputs < 256 nA
 
     # Buck-converter
     V_output_mV: 2400
     V_buck_drop_mV: 0.0  # simulate LDO min voltage differential or output-diode
 
     LUT_output_efficiency: [ 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00 ] # array[12] depending on output_current
-    LUT_output_I_min_log2_nA: 0  # 2^8 = 256 nA -> array[0] is for inputs < 256 nA, see notes on LUT_input for explanation
+    LUT_output_I_min_log2_nA: 1  # 2^8 = 256 nA -> array[0] is for inputs < 256 nA, see notes on LUT_input for explanation
 
     owner: Ingmar
     group: NES Lab

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source_fixture.yaml
@@ -116,7 +116,7 @@
   parameters:
     id: 1020
     name: BQ25504
-    description: TI BQ25504 with integrated boost-converter
+    description: TI BQ25504 with integrated boost-converter. Values are taken from the DK-Board.
     inherit_from: neutral # to complete undefined vars
     enable_boost: true # if false -> v_intermediate = v_input, output-switch-hysteresis is still usable
 
@@ -126,16 +126,16 @@
     V_input_max_mV: 3000
     I_input_max_mA: 100
 
-    C_intermediate_uF: 22.0  # primary storage-Cap
+    C_intermediate_uF: 100.0  # primary storage-Cap
     V_intermediate_init_mV: 3000 # allow a proper / fast startup
     I_intermediate_leak_nA: 330
 
-    V_intermediate_enable_threshold_mV: 2600 # -> target gets connected (hysteresis-combo with next value)
+    V_intermediate_enable_threshold_mV: 1000 # -> target gets connected (hysteresis-combo with next value)
     V_intermediate_disable_threshold_mV: 0 # -> target gets disconnected
     interval_check_thresholds_ms: 64.0  # some BQs check every 64 ms if output should be disconnected
 
     V_pwr_good_enable_threshold_mV: 2800 # target is informed by pwr-good on output-pin (hysteresis) -> for intermediate voltage
-    V_pwr_good_disable_threshold_mV: 2400
+    V_pwr_good_disable_threshold_mV: 2340
     immediate_pwr_good_signal: false  # 1: activate instant schmitt-trigger, 0: stay in interval for checking thresholds
 
     # Boost Converter

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source_fixture.yaml
@@ -56,7 +56,9 @@
       [ 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00 ],
       [ 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00 ],
       [ 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00 ],
-    ] # input-array[12][12] depending on array[inp_voltage][log(inp_current)], influence of cap-voltage is not implemented
+    ]
+    # input-array[12][12] depending on array[inp_voltage][log(inp_current)],
+    # influence of cap-voltage is not implemented
     LUT_input_V_min_log2_uV: 0 # 2^7 = 128 uV -> array[0] is for inputs < 128 uV
     LUT_input_I_min_log2_nA: 1 # 2^8 = 256 nA -> array[0] is for inputs < 256 nA
 
@@ -129,7 +131,7 @@
     I_intermediate_leak_nA: 330
 
     V_intermediate_enable_threshold_mV: 2600 # -> target gets connected (hysteresis-combo with next value)
-    V_intermediate_disable_threshold_mV: 2300 # -> target gets disconnected
+    V_intermediate_disable_threshold_mV: 0 # -> target gets disconnected
     interval_check_thresholds_ms: 64.0  # some BQs check every 64 ms if output should be disconnected
 
     V_pwr_good_enable_threshold_mV: 2800 # target is informed by pwr-good on output-pin (hysteresis) -> for intermediate voltage

--- a/shepherd_core/shepherd_core/reader.py
+++ b/shepherd_core/shepherd_core/reader.py
@@ -172,13 +172,13 @@ class Reader:
         """Update internal states, helpful after resampling or other changes in data-group."""
         self.h5file.flush()
         sample_count = self.ds_time.shape[0]
-        duration_raw = self.ds_time[sample_count - 1] - self.ds_time[0]
+        duration_raw = self.ds_time[sample_count - 1] - self.ds_time[0] if sample_count > 0 else 0
         if (sample_count > 0) and (duration_raw > 0):
             # this assumes iso-chronous sampling
             duration_s = self._cal.time.raw_to_si(duration_raw)
             self.sample_interval_s = duration_s / sample_count
             self.sample_interval_ns = int(10**9 * self.sample_interval_s)
-            self.samplerate_sps = max(int(sample_count / duration_s), 1)
+            self.samplerate_sps = max(int((sample_count - 1) / duration_s), 1)
         self.runtime_s = round(self.ds_voltage.shape[0] / self.samplerate_sps, 1)
         self.buffers_n = int(self.ds_voltage.shape[0] // self.samples_per_buffer)
         if isinstance(self.file_path, Path):

--- a/shepherd_core/shepherd_core/reader.py
+++ b/shepherd_core/shepherd_core/reader.py
@@ -84,6 +84,7 @@ class Reader:
 
         # init stats
         self.runtime_s: float = 0
+        self.buffers_n: int = 0
         self.file_size: int = 0
         self.data_rate: float = 0
 
@@ -176,6 +177,7 @@ class Reader:
             self.sample_interval_ns = int(10**9 * self.sample_interval_s)
             self.samplerate_sps = max(int(10**9 // self.sample_interval_ns), 1)
         self.runtime_s = round(self.ds_voltage.shape[0] / self.samplerate_sps, 1)
+        self.buffers_n = int(self.ds_voltage.shape[0] // self.samples_per_buffer)
         if isinstance(self.file_path, Path):
             self.file_size = self.file_path.stat().st_size
         else:

--- a/shepherd_core/shepherd_core/reader.py
+++ b/shepherd_core/shepherd_core/reader.py
@@ -171,11 +171,14 @@ class Reader:
     def _refresh_file_stats(self) -> None:
         """Update internal states, helpful after resampling or other changes in data-group."""
         self.h5file.flush()
-        if (self.ds_time.shape[0] > 1) and (self.ds_time[1] != self.ds_time[0]):
-            # this assumes isochronal sampling
-            self.sample_interval_s = self._cal.time.raw_to_si(self.ds_time[1] - self.ds_time[0])
+        sample_count = self.ds_time.shape[0]
+        duration_raw = self.ds_time[sample_count - 1] - self.ds_time[0]
+        if (sample_count > 0) and (duration_raw > 0):
+            # this assumes iso-chronous sampling
+            duration_s = self._cal.time.raw_to_si(duration_raw)
+            self.sample_interval_s = duration_s / sample_count
             self.sample_interval_ns = int(10**9 * self.sample_interval_s)
-            self.samplerate_sps = max(int(10**9 // self.sample_interval_ns), 1)
+            self.samplerate_sps = max(int(sample_count / duration_s), 1)
         self.runtime_s = round(self.ds_voltage.shape[0] / self.samplerate_sps, 1)
         self.buffers_n = int(self.ds_voltage.shape[0] // self.samples_per_buffer)
         if isinstance(self.file_path, Path):

--- a/shepherd_core/shepherd_core/version.py
+++ b/shepherd_core/shepherd_core/version.py
@@ -1,3 +1,3 @@
 """Separated string avoids circular imports."""
 
-version: str = "2024.7.4"
+version: str = "2024.8.1"

--- a/shepherd_core/shepherd_core/vsource/virtual_converter_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_converter_model.py
@@ -108,8 +108,6 @@ class VirtualConverterModel:
         if self.enable_boost:
             if input_voltage_uV < self._cfg.V_input_boost_threshold_uV:
                 input_voltage_uV = 0.0
-            if input_voltage_uV > self.V_mid_uV:
-                input_voltage_uV = self.V_mid_uV
         elif not self.enable_storage:
             # direct connection
             self.V_mid_uV = input_voltage_uV

--- a/shepherd_core/shepherd_core/vsource/virtual_converter_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_converter_model.py
@@ -25,8 +25,8 @@ from ..data_models.content.virtual_source import ConverterPRUConfig
 class PruCalibration:
     """part of calibration.h."""
 
-    # negative residue compensation:
-    # compensate for noise around 0 - current uint-design cuts away negative part and leads to biased mean()
+    # negative residue compensation - compensate for noise around 0
+    # -> current uint-design cuts away negative part and leads to biased mean()
     NOISE_ESTIMATE_nA: int = 2000
     RESIDUE_SIZE_FACTOR: int = 30
     RESIDUE_MAX_nA: int = NOISE_ESTIMATE_nA * RESIDUE_SIZE_FACTOR
@@ -36,7 +36,7 @@ class PruCalibration:
         self.cal = cal_emu if cal_emu else CalibrationEmulator()
 
     def conv_adc_raw_to_nA(self, current_raw: int) -> float:
-        I_nA = self.cal.adc_C_A.raw_to_si(current_raw) * (10 ** 9)
+        I_nA = self.cal.adc_C_A.raw_to_si(current_raw) * (10**9)
         if self.cal.adc_C_A.offset < 0:
             if I_nA > self.negative_residue_nA:
                 I_nA -= self.negative_residue_nA
@@ -104,7 +104,7 @@ class VirtualConverterModel:
         self.vsource_skip_gpio_logging: bool = False
 
     def calc_inp_power(self, input_voltage_uV: float, input_current_nA: float) -> int:
-        # Next 2 lines are Python-specific (model uint)
+        # Next 2 lines are Python-specific (model unsigned int)
         input_voltage_uV = max(0.0, input_voltage_uV)
         input_current_nA = max(0.0, input_current_nA)
 
@@ -149,7 +149,7 @@ class VirtualConverterModel:
         return round(self.P_inp_fW)  # Python-specific, added for easier testing
 
     def calc_out_power(self, current_adc_raw: int) -> int:
-        # Next 2 lines are Python-specific (model uint / int)
+        # Next 2 lines are Python-specific (model unsigned int)
         current_adc_raw = max(0, current_adc_raw)
         current_adc_raw = min((2**18) - 1, current_adc_raw)
 

--- a/shepherd_core/shepherd_core/vsource/virtual_converter_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_converter_model.py
@@ -25,12 +25,28 @@ from ..data_models.content.virtual_source import ConverterPRUConfig
 class PruCalibration:
     """part of calibration.h."""
 
+    # negative residue compensation:
+    # compensate for noise around 0 - current uint-design cuts away negative part and leads to biased mean()
+    NOISE_ESTIMATE_nA: int = 2000
+    RESIDUE_SIZE_FACTOR: int = 30
+    RESIDUE_MAX_nA: int = NOISE_ESTIMATE_nA * RESIDUE_SIZE_FACTOR
+    negative_residue_nA = 0
+
     def __init__(self, cal_emu: Optional[CalibrationEmulator] = None) -> None:
         self.cal = cal_emu if cal_emu else CalibrationEmulator()
 
     def conv_adc_raw_to_nA(self, current_raw: int) -> float:
-        return self.cal.adc_C_A.raw_to_si(current_raw) * (10**9)
-        # TODO: add feature "negative residue compensation" to here
+        I_nA = self.cal.adc_C_A.raw_to_si(current_raw) * (10 ** 9)
+        if self.cal.adc_C_A.offset < 0:
+            if I_nA > self.negative_residue_nA:
+                I_nA -= self.negative_residue_nA
+                self.negative_residue_nA = 0
+            else:
+                self.negative_residue_nA = self.negative_residue_nA - I_nA
+                if self.negative_residue_nA > self.RESIDUE_MAX_nA:
+                    self.negative_residue_nA = self.RESIDUE_MAX_nA
+                I_nA = 0
+        return I_nA
 
     @staticmethod
     def conv_adc_raw_to_uV(voltage_raw: int) -> float:
@@ -88,10 +104,11 @@ class VirtualConverterModel:
         self.vsource_skip_gpio_logging: bool = False
 
     def calc_inp_power(self, input_voltage_uV: float, input_current_nA: float) -> int:
-        # Next 2 lines are Python-specific
+        # Next 2 lines are Python-specific (model uint)
         input_voltage_uV = max(0.0, input_voltage_uV)
         input_current_nA = max(0.0, input_current_nA)
 
+        # Input diode
         if input_voltage_uV > self._cfg.V_input_drop_uV:
             input_voltage_uV -= self._cfg.V_input_drop_uV
         else:
@@ -132,7 +149,7 @@ class VirtualConverterModel:
         return round(self.P_inp_fW)  # Python-specific, added for easier testing
 
     def calc_out_power(self, current_adc_raw: int) -> int:
-        # Next 2 lines are Python-specific
+        # Next 2 lines are Python-specific (model uint / int)
         current_adc_raw = max(0, current_adc_raw)
         current_adc_raw = min((2**18) - 1, current_adc_raw)
 

--- a/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
@@ -35,7 +35,10 @@ class VirtualHarvesterModel:
 
         # INIT global vars: shared states
         self.voltage_set_uV: int = self._cfg.voltage_uV + 1
-        self.interval_step: int = max(0, self._cfg.interval_n - (2 * self._cfg.window_size))
+        if self._cfg.interval_n > 2 * self._cfg.window_size:
+            self.interval_step = self._cfg.interval_n - (2 * self._cfg.window_size)
+        else:
+            self.interval_step = 2**30
         # ⤷ intake two ivcurves before overflow / reset
         self.is_rising: bool = (self._cfg.hrv_mode & (2**1)) != 0
 
@@ -113,7 +116,9 @@ class VirtualHarvesterModel:
         return self.voltage_hold, self.current_hold
 
     def ivcurve_2_mppt_voc(self, _voltage_uV: int, _current_nA: int) -> Tuple[int, int]:
-        self.interval_step = (self.interval_step + 1) % self._cfg.interval_n
+        self.interval_step = self.interval_step + 1
+        if self.interval_step >= self._cfg.interval_n:
+            self.interval_step = 0
         self.age_nxt += 1
         self.age_now += 1
 
@@ -140,7 +145,9 @@ class VirtualHarvesterModel:
         return _voltage_uV, _current_nA
 
     def ivcurve_2_mppt_po(self, _voltage_uV: int, _current_nA: int) -> Tuple[int, int]:
-        self.interval_step = (self.interval_step + 1) % self._cfg.interval_n
+        self.interval_step = self.interval_step + 1
+        if self.interval_step >= self._cfg.interval_n:
+            self.interval_step = 0
 
         _voltage_uV, _current_nA = self.ivcurve_2_cv(_voltage_uV, _current_nA)
 

--- a/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
@@ -35,7 +35,8 @@ class VirtualHarvesterModel:
 
         # INIT global vars: shared states
         self.voltage_set_uV: int = self._cfg.voltage_uV + 1
-        self.interval_step: int = 2**30
+        self.interval_step: int = max(0, self._cfg.interval_n - (2 * self._cfg.window_size))
+        # ⤷ intake two ivcurves before overflow / reset
         self.is_rising: bool = (self._cfg.hrv_mode & (2**1)) != 0
 
         # PO-Relevant, iv & adc
@@ -51,6 +52,7 @@ class VirtualHarvesterModel:
         self.voltage_hold: int = 0
         self.current_hold: int = 0
         self.voltage_step_x4_uV: int = self._cfg.voltage_step_uV * 4
+        self.age_max: int = 2 * self._cfg.window_size
 
         # INIT static vars: CV
         self.voltage_last: int = 0
@@ -124,7 +126,7 @@ class VirtualHarvesterModel:
             self.voc_nxt = _voltage_uV
             self.age_nxt = 0
 
-        if (self.age_now > self._cfg.window_size) or (self.voc_nxt <= self.voc_now):
+        if (self.age_now > self.age_max) or (self.voc_nxt <= self.voc_now):
             self.age_now = self.age_nxt
             self.voc_now = self.voc_nxt
             self.age_nxt = 0
@@ -194,7 +196,7 @@ class VirtualHarvesterModel:
             self.voltage_nxt = _voltage_uV
             self.current_nxt = _current_nA
 
-        if (self.age_now > self._cfg.window_size) or (self.power_nxt >= self.power_now):
+        if (self.age_now > self.age_max) or (self.power_nxt >= self.power_now):
             self.age_now = self.age_nxt
             self.power_now = self.power_nxt
             self.voltage_now = self.voltage_nxt

--- a/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
@@ -59,9 +59,10 @@ class VirtualHarvesterModel:
 
         # INIT static vars: VOC
         self.age_now: int = 0
-        self.voc_now: int = 0
+        self.voc_now: int = self._cfg.voltage_max_uV
         self.age_nxt: int = 0
-        self.voc_nxt: int = 0
+        self.voc_nxt: int = self._cfg.voltage_max_uV
+        self.voc_min: int = max(1000, self._cfg.voltage_min_uV)
 
         # INIT static vars: PO
         # already done: interval step
@@ -117,7 +118,7 @@ class VirtualHarvesterModel:
         if (
             (_current_nA < self._cfg.current_limit_nA)
             and (_voltage_uV < self.voc_nxt)
-            and (_voltage_uV >= self._cfg.voltage_min_uV)
+            and (_voltage_uV >= self.voc_min)
             and (_voltage_uV <= self._cfg.voltage_max_uV)
         ):
             self.voc_nxt = _voltage_uV

--- a/shepherd_core/shepherd_core/writer.py
+++ b/shepherd_core/shepherd_core/writer.py
@@ -149,9 +149,12 @@ class Writer(Reader):
             raise ValueError(msg)
 
         if self._modify:
-            self._mode = mode
-            self._datatype = datatype
-            self._window_samples = window_samples
+            if mode:
+                self._mode = mode
+            if datatype:
+                self._datatype = datatype
+            if window_samples:
+                self._window_samples = window_samples
         else:
             self._mode = mode if isinstance(mode, str) else self.mode_default
             self._datatype = (

--- a/shepherd_core/shepherd_core/writer.py
+++ b/shepherd_core/shepherd_core/writer.py
@@ -151,10 +151,16 @@ class Writer(Reader):
         if self._modify:
             if mode:
                 self._mode = mode
+            if not hasattr(self, "_mode"):
+                self._mode = self.mode_default
             if datatype:
                 self._datatype = datatype
+            if not hasattr(self, "_datatype"):
+                self._datatype = self.datatype_default
             if window_samples:
                 self._window_samples = window_samples
+            if not hasattr(self, "_window_samples"):
+                self._window_samples = 0
         else:
             self._mode = mode if isinstance(mode, str) else self.mode_default
             self._datatype = (
@@ -338,6 +344,7 @@ class Writer(Reader):
             current: ndarray in physical-unit A
 
         """
+        # TODO: make timestamp optional to add it raw, OR unify append with granular raw-switch
         timestamp = self._cal.time.si_to_raw(timestamp)
         voltage = self._cal.voltage.si_to_raw(voltage)
         current = self._cal.current.si_to_raw(current)

--- a/shepherd_data/pyproject.toml
+++ b/shepherd_data/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pandas>=2.0.0",  # full-version, v2 is OK
     "pyYAML",
     "scipy",   # full-version
-    "shepherd-core[inventory]>=2024.7.4",
+    "shepherd-core[inventory]>=2024.8.1",
     "tqdm",    # full-version
 ]
 

--- a/shepherd_data/shepherd_data/__init__.py
+++ b/shepherd_data/shepherd_data/__init__.py
@@ -11,7 +11,7 @@ from shepherd_core import Writer
 
 from .reader import Reader
 
-__version__ = "2024.7.4"
+__version__ = "2024.8.1"
 
 __all__ = [
     "Reader",

--- a/shepherd_data/shepherd_data/reader.py
+++ b/shepherd_data/shepherd_data/reader.py
@@ -399,34 +399,32 @@ class Reader(CoreReader):
         if isinstance(data, dict):
             data = [data]
         if only_pwr:
-            fig = plt.figure(figsize=(width, height))
+            fig, ax = plt.subplots(1, 1, figsize=(width, height), layout="tight")
+            axs = [ax]
             fig.suptitle("Power-Trace")
-            plt.xlabel("time [s]")
-            plt.ylabel("power [mW]")
-            for date in data:
-                plt.plot(
-                    date["time"], date["voltage"] * date["current"] * 10**3, label=date["name"]
-                )
-            if len(data) > 1:
-                plt.legend(loc="lower center", ncol=len(data))
         else:
-            fig, axes = plt.subplots(3, 1, sharex="all")
+            fig, axs = plt.subplots(3, 1, sharex="all", figsize=(width, height), layout="tight")
             fig.suptitle("Voltage, current & power")
-            for date in data:
-                axes[0].plot(date["time"], date["voltage"], label=date["name"])
-                axes[1].plot(date["time"], date["current"] * 10**3, label=date["name"])
-                axes[2].plot(
-                    date["time"], date["voltage"] * date["current"] * 10**3, label=date["name"]
-                )
-            axes[0].set_ylabel("voltage [V]")
-            axes[1].set_ylabel("current [mA]")
-            axes[2].set_ylabel("power [mW]")
-            if len(data) > 1:
-                axes[0].legend(loc="lower center", ncol=len(data))
-            axes[2].set_xlabel("time [s]")
-        fig.set_figwidth(width)
-        fig.set_figheight(height)
-        fig.tight_layout()
+            axs[0].set_ylabel("voltage [V]")
+            axs[1].set_ylabel("current [mA]")
+            # last axis is set below
+
+        for date in data:
+            if not only_pwr:
+                axs[0].plot(date["time"], date["voltage"], label=date["name"])
+                axs[1].plot(date["time"], date["current"] * 10**3, label=date["name"])
+            axs[-1].plot(
+                date["time"], date["voltage"] * date["current"] * 10**3, label=date["name"]
+            )
+
+        if len(data) > 1:
+            axs[0].legend(loc="lower center", ncol=len(data))
+        axs[-1].set_xlabel("time [s]")
+        axs[-1].set_ylabel("power [mW]")
+        for ax in axs:
+            # deactivates offset-creation for ax-ticks
+            ax.get_yaxis().get_major_formatter().set_useOffset(False)
+            ax.get_xaxis().get_major_formatter().set_useOffset(False)
         return fig
 
     def plot_to_file(


### PR DESCRIPTION
## v2024.8.1

- plotting: disable creation of tick-offset
- cal: add si-unit
- add `shepherd_core/example/vsource_emulation.py` that processes hdf5-recordings and also generates them
- add `shepherd_core/examples/eenv_generator.py` to create static energy environments
- virtual source model
  - fix off-by-1 error in rows of efficiency-LUTs
  - remove limiting-behavior of boost-regulator
  - add residue-feature to calibration-converters
  - bq25504 - to not cut-off output, increase capacity to 100 uF and adapt pwr-good-voltages (close to DK)
- harvester model
  - fix voc-harvesting
  - improve windowing setting for ingested ivcurve
  - port behavior from PRU
  - port behavior from PRU
- ivcurve-harvesting-fixture: make 110 Hz version the new default
- isc-voc-harvesting-fixture: give 4x more time to settle
- hdf5-writer: only modify non-None elements
- hdf5-reader: improve samplerate calculation