### PR TITLE
v2024.11.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2024.11.2
+current_version = 2024.11.3
 commit = False
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # History of Changes
 
+## v2024.11.3
+
+- Core.Reader can now determine voltage_step from source-file
+- HarvesterPRUConfig.from_vhrv() needs voltage_step IF input is IVCurve for emulation
+  - same for init() of VirtualSourceModel
+  - this fixes a bug that could ruin emulations with ivcurves (#73)
+
 ## v2024.11.2
 
 - adapt fixtures to recent testbed-restructure

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ coverage report
 ```shell
 pipenv shell
 
-bump2version --allow-dirty --new-version 2024.11.2 patch
+bump2version --allow-dirty --new-version 2024.11.3 patch
 # ⤷ format: year.month.patch_release
 
 pre-commit run --all-files

--- a/shepherd_core/shepherd_core/version.py
+++ b/shepherd_core/shepherd_core/version.py
@@ -1,3 +1,3 @@
 """Separated string avoids circular imports."""
 
-version: str = "2024.11.2"
+version: str = "2024.11.3"

--- a/shepherd_core/shepherd_core/vsource/virtual_harvester_simulation.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_harvester_simulation.py
@@ -47,6 +47,7 @@ def simulate_harvester(
         for_emu=True,
         dtype_in=file_inp.get_datatype(),
         window_size=file_inp.get_window_samples(),
+        voltage_step_V=file_inp.get_voltage_step(),
     )
     hrv = VirtualHarvesterModel(hrv_pru)
     e_out_Ws = 0.0

--- a/shepherd_core/shepherd_core/vsource/virtual_source_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_source_model.py
@@ -31,6 +31,7 @@ class VirtualSourceModel:
         cal_emu: CalibrationEmulator,
         dtype_in: EnergyDType = EnergyDType.ivsample,
         window_size: Optional[int] = None,
+        voltage_step_V: Optional[float] = None,
         *,
         log_intermediate: bool = False,
     ) -> None:
@@ -50,6 +51,7 @@ class VirtualSourceModel:
             for_emu=True,
             dtype_in=dtype_in,
             window_size=window_size,
+            voltage_step_V=voltage_step_V,
         )
 
         self.hrv: VirtualHarvesterModel = VirtualHarvesterModel(hrv_config)

--- a/shepherd_core/shepherd_core/vsource/virtual_source_simulation.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_source_simulation.py
@@ -56,6 +56,7 @@ def simulate_source(
         dtype_in=file_inp.get_datatype(),
         log_intermediate=False,
         window_size=file_inp.get_window_samples(),
+        voltage_step_V=file_inp.get_voltage_step(),
     )
     i_out_nA = 0
     e_out_Ws = 0.0

--- a/shepherd_core/tests/vsource/test_converter.py
+++ b/shepherd_core/tests/vsource/test_converter.py
@@ -26,6 +26,7 @@ def src_model(
     name: str,
     dtype_in: EnergyDType = EnergyDType.ivsample,
     window_size: Optional[int] = None,
+    voltage_step_V: Optional[float] = None,
 ) -> VirtualSourceModel:
     src_config = VirtualSourceConfig(name=name, V_intermediate_init_mV=2000)
     cal_emu = CalibrationEmulator()
@@ -35,6 +36,7 @@ def src_model(
         log_intermediate=False,
         dtype_in=dtype_in,
         window_size=window_size,
+        voltage_step_V=voltage_step_V,
     )
 
 
@@ -145,9 +147,12 @@ def test_vsource_vsrc_create_files(
 @pytest.mark.parametrize("src_name", src_list)
 def test_vsource_vsrc_sim_curve(src_name: str, file_ivcurve: Path) -> None:
     with Reader(file_ivcurve) as file:
-        window_size = file.get_window_samples()
-        dtype = file.get_datatype()
-        src = src_model("BQ25504s", dtype_in=dtype, window_size=window_size)
+        src = src_model(
+            "BQ25504s",
+            dtype_in=file.get_datatype(),
+            window_size=file.get_window_samples(),
+            voltage_step_V=file.get_voltage_step(),
+        )
         for _t, _v, _i in file.read_buffers():
             length = max(_v.size, _i.size)
             for _n in range(length):
@@ -157,9 +162,12 @@ def test_vsource_vsrc_sim_curve(src_name: str, file_ivcurve: Path) -> None:
 @pytest.mark.parametrize("src_name", src_list)
 def test_vsource_vsrc_sim_sample(src_name: str, file_ivsample: Path) -> None:
     with Reader(file_ivsample) as file:
-        window_size = file.get_window_samples()
-        dtype = file.get_datatype()
-        src = src_model("BQ25504s", dtype_in=dtype, window_size=window_size)
+        src = src_model(
+            "BQ25504s",
+            dtype_in=file.get_datatype(),
+            window_size=file.get_window_samples(),
+            voltage_step_V=file.get_voltage_step(),
+        )
         for _t, _v, _i in file.read_buffers():
             length = max(_v.size, _i.size)
             for _n in range(length):

--- a/shepherd_data/pyproject.toml
+++ b/shepherd_data/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pandas>=2.0.0",  # full-version, v2 is OK
     "pyYAML",
     "scipy",   # full-version
-    "shepherd-core[inventory]>=2024.11.2",  # libs are strongly coupled
+    "shepherd-core[inventory]>=2024.11.3",  # libs are strongly coupled
     "tqdm",    # full-version
 ]
 

--- a/shepherd_data/shepherd_data/__init__.py
+++ b/shepherd_data/shepherd_data/__init__.py
@@ -11,7 +11,7 @@ from shepherd_core import Writer
 
 from .reader import Reader
 
-__version__ = "2024.11.2"
+__version__ = "2024.11.3"
 
 __all__ = [
     "Reader",


### PR DESCRIPTION
- Core.Reader can now determine voltage_step from source-file
- HarvesterPRUConfig.from_vhrv() needs voltage_step IF input is IVCurve for emulation
  - same for init() of VirtualSourceModel
  - this fixes a bug that could ruin emulations with ivcurves (#72)