### PR TITLE
v2025.04.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2025.04.1
+current_version = 2025.04.2
 commit = False
 tag = False
 

--- a/.github/workflows/py_publish.yml
+++ b/.github/workflows/py_publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python 🐍
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies 🔧
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/py_unittest.yml
+++ b/.github/workflows/py_unittest.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [ "3.12", "3.10", "3.8" ] # 5 versions / years
+        python-version: [ "3.13", "3.11", "3.9" ] # 5 versions / years
 
     runs-on: ${{ matrix.os }}
 
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Python 🐍
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Run Pre-Commit Tests 🧪
         uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,3 @@ repos:
       - id: validate-pyproject
 
 # TODO: github.com/PyCQA/pydocstyle
-
-# default_language_version:
-#    python: python3.8

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -7,7 +7,6 @@ select = ["ALL"]
 ignore = [
     "N802", "N803", "N806", "N815", "N816", # naming (si-units should stay)
     "PLR2004", # magic values
-    "TID252", # relative imports from parent
     "PLR0904", "PLR0911", "PLR0912", "PLR0913", "PLR0915", # complexity
     "C901", # complexity
     "ANN401",  # Any as valid type

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 line-length = 100
-target-version = "py38"
+target-version = "py39"
 output-format = "concise"
 
 [lint]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # History of Changes
 
+## v2025.04.2
+
+- drop python 3.8 support
+- supported python is now 3.9 - 3.13
+
 ## v2025.04.1
 
 - Core.Reader.read_buffers()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - drop python 3.8 support
 - supported python is now 3.9 - 3.13
+- heavy changes in typesystem
+- pathlib now has .with_stem() to simplify code
 
 ## v2025.04.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@
 - drop python 3.8 support
 - supported python is now 3.9 - 3.13
 - heavy changes in typesystem
+  - user facing interfaces should be safe to use
+  - mypy was used to find possible bugs
 - pathlib now has .with_stem() to simplify code
+- rename constants to upper-case
+  - 1-to-1: samplerate_sps_default,
+  - core.Reader().mode_dtype_dict -> .MODE_TO_DTYPE
+  - core.Reader().samples_per_buffer -> .BUFFER_SAMPLES_N
+- replace relative imports from parent with absolute ones
 
 ## v2025.04.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 - drop python 3.8 support
 - supported python is now 3.9 - 3.13
-- heavy changes in typesystem
-  - user facing interfaces should be safe to use
-  - mypy was used to find possible bugs
+- heavy changes in typesystem - mypy was used to find possible bugs (NOTE: still work in progress)
+- user facing interfaces should be safer to use
 - pathlib now has .with_stem() to simplify code
 - rename constants to upper-case
   - 1-to-1: samplerate_sps_default,

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ coverage report
 ```shell
 pipenv shell
 
-bump2version --allow-dirty --new-version 2025.04.1 patch
+bump2version --allow-dirty --new-version 2025.04.2 patch
 # ⤷ format: year.month.patch_release
 
 pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ bump2version --allow-dirty --new-version 2025.04.2 patch
 pre-commit run --all-files
 
 # additional QA-Tests (currently with open issues)
-pyright
+cd shepherd_core
+mypy .
 
 # inside sub-modules unittests
 cd shepherd_core

--- a/extra/gen_firmwares.py
+++ b/extra/gen_firmwares.py
@@ -8,7 +8,6 @@
 import shutil
 from io import BytesIO
 from pathlib import Path
-from typing import Dict
 from urllib.request import urlopen
 from zipfile import ZipFile
 
@@ -67,7 +66,7 @@ if __name__ == "__main__":
                 logger.error("FW not found, will skip: %s", path_elf.as_posix())
 
             # debug-part below
-            sizeof: Dict[str, int] = {}
+            sizeof: dict[str, int] = {}
             sizeof["elf"] = path_elf.stat().st_size
             files_hex = [each for each in path_sub.iterdir() if each.endswith(".hex")]
             if files_hex:

--- a/extra/link-visualizer/create_link_svg.py
+++ b/extra/link-visualizer/create_link_svg.py
@@ -4,9 +4,7 @@ import logging
 import re
 from collections.abc import Mapping
 from pathlib import Path
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 logging.basicConfig(level=logging.INFO)
 
@@ -19,7 +17,7 @@ draw_nodes: bool = True
 # -------------------------------------------------------
 
 # node locations in pixel
-NODES: Mapping[int, Tuple[int, int]] = {
+NODES: Mapping[int, tuple[int, int]] = {
     1: (104, 110),
     2: (207, 70),
     3: (326, 31),
@@ -50,7 +48,7 @@ def indent(s: str, pre: str = "\t", *, empty: bool = False) -> str:
 class SVGNodes:
     def __init__(self, color: str = "#FFFFFF") -> None:
         self.color: str = color
-        self._nodes: List[str] = []
+        self._nodes: list[str] = []
 
     @staticmethod
     def _gen_node(node: int, fill: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ include = [
     './shepherd_core/',
     './shepherd_data/',
 ]
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 pythonPlatform = "All"
 reportMissingParameterType = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,12 @@ include = [
 pythonVersion = "3.9"
 pythonPlatform = "All"
 reportMissingParameterType = true
+
+[tool.mypy]
+python_version = 3.9
+ignore_missing_imports = true
+disable_error_code = ["call-arg", ]
+exclude = [
+    "build/",
+    ".egg-info/",
+]

--- a/shepherd_core/examples/simulate_vharvester.py
+++ b/shepherd_core/examples/simulate_vharvester.py
@@ -61,11 +61,7 @@ with Reader(file_ivcurve, verbose=False) as file:
 
 # Simulation
 for hrv_name in hrv_list:
-    file_output = (
-        file_ivcurve.with_name(file_ivcurve.stem + "_" + hrv_name + file_ivcurve.suffix)
-        if save_files
-        else None
-    )
+    file_output = file_ivcurve.with_stem(file_ivcurve.stem + "_" + hrv_name) if save_files else None
     E_out_Ws = simulate_harvester(
         config=VirtualHarvesterConfig(name=hrv_name),
         path_input=file_ivcurve,

--- a/shepherd_core/examples/simulate_vsource.py
+++ b/shepherd_core/examples/simulate_vsource.py
@@ -42,11 +42,7 @@ tgt = ResistiveTarget(R_Ohm=1_000, controlled=True)
 save_files = True
 
 for src_name in src_list:
-    file_output = (
-        file_input.with_name(file_input.stem + "_emu_" + src_name + file_input.suffix)
-        if save_files
-        else None
-    )
+    file_output = file_input.with_stem(file_input.stem + "_emu_" + src_name) if save_files else None
 
     e_out_Ws = simulate_source(
         config=VirtualSourceConfig(

--- a/shepherd_core/pyproject.toml
+++ b/shepherd_core/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -25,7 +24,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "h5py",
     "numpy",
@@ -111,6 +110,6 @@ source = ["shepherd_core"]
 omit = ["*/shepherd_data/*"]
 
 [tool.mypy]
-python_version = 3.8
+python_version = 3.9
 ignore_missing_imports = true
 disable_error_code = ["call-arg", ]

--- a/shepherd_core/pyproject.toml
+++ b/shepherd_core/pyproject.toml
@@ -113,3 +113,7 @@ omit = ["*/shepherd_data/*"]
 python_version = 3.9
 ignore_missing_imports = true
 disable_error_code = ["call-arg", ]
+exclude = [
+    "build/",
+    ".egg-info/",
+]

--- a/shepherd_core/shepherd_core/calibration_hw_def.py
+++ b/shepherd_core/shepherd_core/calibration_hw_def.py
@@ -10,26 +10,26 @@ currently configured for cape v2.4c
 """
 
 # both current channels have a 0.1 % shunt resistance of
-R_SHT = 2.0  # [ohm]
+R_SHT: float = 2.0  # [ohm]
 # the instrumentation amplifiers are configured for gain of
-G_INST_AMP = 48  # [n]
+G_INST_AMP: int = 48  # [n]
 # we use the ADC's internal reference with
-V_REF_ADC = 4.096  # [V]
+V_REF_ADC: float = 4.096  # [V]
 # range of current channels is
-G_ADC_I = 1.25  # [gain / V_REF]
+G_ADC_I: float = 1.25  # [gain / V_REF]
 # range of voltage channels is
-G_ADC_V = 1.25  # [gain / V_REF]
+G_ADC_V: float = 1.25  # [gain / V_REF]
 # bit resolution of ADC
-M_ADC = 18  # [bit]
+M_ADC: int = 18  # [bit]
 # DACs use internal reference with
-V_REF_DAC = 2.5  # [V]
+V_REF_DAC: float = 2.5  # [V]
 # gain of DAC is set to
-G_DAC = 2  # [n]
+G_DAC: int = 2  # [n]
 # bit resolution of DAC
-M_DAC = 16  # [bit]
+M_DAC: int = 16  # [bit]
 # DERIVED VARIABLES
-RAW_MAX_ADC = 2**M_ADC - 1
-RAW_MAX_DAC = 2**M_DAC - 1
+RAW_MAX_ADC: int = 2**M_ADC - 1
+RAW_MAX_DAC: int = 2**M_DAC - 1
 
 
 def adc_current_to_raw(current: float, *, limited: bool = True) -> int:

--- a/shepherd_core/shepherd_core/commons.py
+++ b/shepherd_core/shepherd_core/commons.py
@@ -1,8 +1,8 @@
 """Container for commonly shared constants."""
 
-samplerate_sps_default: int = 100_000
+SAMPLERATE_SPS_DEFAULT: int = 100_000
 
-uid_str_default: str = "SHEPHERD_NODE_ID"
-uid_len_default: int = 2
+UID_NAME: str = "SHEPHERD_NODE_ID"
+UID_SIZE: int = 2
 
-testbed_server_default: str = "http://127.0.0.1:8000/shepherd"
+TESTBED_SERVER_URI: str = "http://127.0.0.1:8000/shepherd"

--- a/shepherd_core/shepherd_core/data_models/base/cal_measurement.py
+++ b/shepherd_core/shepherd_core/data_models/base/cal_measurement.py
@@ -1,13 +1,12 @@
 """Models for the process of calibration a device by measurements."""
 
-from typing import List
+from typing import Annotated
 from typing import Optional
 
 import numpy as np
 from pydantic import Field
 from pydantic import PositiveFloat
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 from .calibration import CalibrationCape
 from .calibration import CalibrationEmulator
@@ -24,7 +23,7 @@ class CalMeasurementPair(ShpModel):
     reference_si: float = 0
 
 
-CalMeasPairs = Annotated[List[CalMeasurementPair], Field(min_length=2)]
+CalMeasPairs = Annotated[list[CalMeasurementPair], Field(min_length=2)]
 
 
 @validate_call

--- a/shepherd_core/shepherd_core/data_models/base/cal_measurement.py
+++ b/shepherd_core/shepherd_core/data_models/base/cal_measurement.py
@@ -36,16 +36,16 @@ def meas_to_cal(data: CalMeasPairs, component: str) -> CalibrationPair:
         y[i] = pair.reference_si
 
     model = np.polyfit(x, y, 1)
-    offset = model[1]
-    gain = model[0]
+    offset: float = float(model[1])
+    gain: float = float(model[0])
 
     # r-squared, Pearson correlation coefficient
-    p = np.poly1d(model)
-    yhat = p(x)
-    ybar = np.sum(y) / len(y)
-    ssreg = np.sum((yhat - ybar) ** 2)
-    sstot = np.sum((y - ybar) ** 2)
-    rval = ssreg / sstot
+    _p = np.poly1d(model)
+    yhat = _p(x)
+    ybar: float = np.sum(y) / len(y)
+    ssreg: float = np.sum((yhat - ybar) ** 2)
+    sstot: float = np.sum((y - ybar) ** 2)
+    rval: float = ssreg / sstot
 
     if rval < 0.999:
         msg = (

--- a/shepherd_core/shepherd_core/data_models/base/calibration.py
+++ b/shepherd_core/shepherd_core/data_models/base/calibration.py
@@ -18,9 +18,10 @@ from pydantic import constr
 from pydantic import validate_call
 from typing_extensions import Self
 
-from ...calibration_hw_def import adc_current_to_raw
-from ...calibration_hw_def import adc_voltage_to_raw
-from ...calibration_hw_def import dac_voltage_to_raw
+from shepherd_core.calibration_hw_def import adc_current_to_raw
+from shepherd_core.calibration_hw_def import adc_voltage_to_raw
+from shepherd_core.calibration_hw_def import dac_voltage_to_raw
+
 from .shepherd import ShpModel
 from .timezone import local_iso_date
 

--- a/shepherd_core/shepherd_core/data_models/base/calibration.py
+++ b/shepherd_core/shepherd_core/data_models/base/calibration.py
@@ -1,11 +1,11 @@
 """Models for the calibration-data to convert between raw & SI-Values."""
 
 import struct
+from collections.abc import Generator
+from collections.abc import Mapping
+from collections.abc import Sequence
 from typing import Callable
-from typing import Generator
-from typing import Mapping
 from typing import Optional
-from typing import Sequence
 from typing import TypeVar
 from typing import Union
 

--- a/shepherd_core/shepherd_core/data_models/base/content.py
+++ b/shepherd_core/shepherd_core/data_models/base/content.py
@@ -2,6 +2,7 @@
 
 import hashlib
 from datetime import datetime
+from typing import Annotated
 from typing import Optional
 from typing import Union
 from uuid import uuid4
@@ -10,7 +11,6 @@ from pydantic import UUID4
 from pydantic import Field
 from pydantic import StringConstraints
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 from typing_extensions import deprecated
 

--- a/shepherd_core/shepherd_core/data_models/base/shepherd.py
+++ b/shepherd_core/shepherd_core/data_models/base/shepherd.py
@@ -2,11 +2,11 @@
 
 import hashlib
 import pathlib
+from collections.abc import Generator
 from datetime import timedelta
 from ipaddress import IPv4Address
 from pathlib import Path
 from typing import Any
-from typing import Generator
 from typing import Optional
 from typing import Union
 from uuid import UUID

--- a/shepherd_core/shepherd_core/data_models/base/shepherd.py
+++ b/shepherd_core/shepherd_core/data_models/base/shepherd.py
@@ -15,27 +15,26 @@ import yaml
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from typing_extensions import Self
-from yaml import Dumper
+from yaml import Node
 from yaml import SafeDumper
-from yaml import ScalarNode
 
 from .timezone import local_now
 from .wrapper import Wrapper
 
 
 def path2str(
-    dumper: Dumper, data: Union[pathlib.Path, pathlib.WindowsPath, pathlib.PosixPath]
-) -> ScalarNode:
+    dumper: SafeDumper, data: Union[pathlib.Path, pathlib.WindowsPath, pathlib.PosixPath]
+) -> Node:
     """Add a yaml-representation for a specific datatype."""
     return dumper.represent_scalar("tag:yaml.org,2002:str", str(data.as_posix()))
 
 
-def time2int(dumper: Dumper, data: timedelta) -> ScalarNode:
+def time2int(dumper: SafeDumper, data: timedelta) -> Node:
     """Add a yaml-representation for a specific datatype."""
     return dumper.represent_scalar("tag:yaml.org,2002:int", str(int(data.total_seconds())))
 
 
-def generic2str(dumper: Dumper, data: Any) -> ScalarNode:
+def generic2str(dumper: SafeDumper, data: Any) -> Node:
     """Add a yaml-representation for a specific datatype."""
     return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
 

--- a/shepherd_core/shepherd_core/data_models/base/wrapper.py
+++ b/shepherd_core/shepherd_core/data_models/base/wrapper.py
@@ -7,7 +7,7 @@ from typing import Optional
 from pydantic import BaseModel
 from pydantic import StringConstraints
 
-from ...version import version
+from shepherd_core.version import version
 
 SafeStrClone = Annotated[str, StringConstraints(pattern=r"^[ -~]+$")]
 # ⤷ copy avoids circular import

--- a/shepherd_core/shepherd_core/data_models/base/wrapper.py
+++ b/shepherd_core/shepherd_core/data_models/base/wrapper.py
@@ -1,11 +1,11 @@
 """Wrapper-related ecosystem for transferring models."""
 
 from datetime import datetime
+from typing import Annotated
 from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import StringConstraints
-from typing_extensions import Annotated
 
 from ...version import version
 

--- a/shepherd_core/shepherd_core/data_models/content/energy_environment.py
+++ b/shepherd_core/shepherd_core/data_models/content/energy_environment.py
@@ -8,8 +8,8 @@ from typing import Optional
 from pydantic import PositiveFloat
 from pydantic import model_validator
 
-from ...testbed_client import tb_client
-from ..base.content import ContentModel
+from shepherd_core.data_models.base.content import ContentModel
+from shepherd_core.testbed_client import tb_client
 
 
 class EnergyDType(str, Enum):

--- a/shepherd_core/shepherd_core/data_models/content/energy_environment.py
+++ b/shepherd_core/shepherd_core/data_models/content/energy_environment.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from pathlib import Path
+from typing import Any
 from typing import Optional
 
 from pydantic import PositiveFloat
@@ -46,7 +47,7 @@ class EnergyEnvironment(ContentModel):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         values, _ = tb_client.try_completing_model(cls.__name__, values)
         # TODO: figure out a way to crosscheck type with actual data
         return tb_client.fill_in_user_data(values)

--- a/shepherd_core/shepherd_core/data_models/content/firmware.py
+++ b/shepherd_core/shepherd_core/data_models/content/firmware.py
@@ -5,6 +5,7 @@ TODO: should be more generalized - currently only supports msp & nRF
 
 from pathlib import Path
 from typing import Annotated
+from typing import Any
 from typing import Optional
 from typing import TypedDict
 from typing import Union
@@ -64,7 +65,7 @@ class Firmware(ContentModel, title="Firmware of Target"):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         values, _ = tb_client.try_completing_model(cls.__name__, values)
         # crosscheck type with actual data
         _type = values.get("data_type")

--- a/shepherd_core/shepherd_core/data_models/content/firmware.py
+++ b/shepherd_core/shepherd_core/data_models/content/firmware.py
@@ -16,11 +16,12 @@ from pydantic import validate_call
 from typing_extensions import Self
 from typing_extensions import Unpack
 
-from ... import fw_tools
-from ...logger import logger
-from ...testbed_client import tb_client
-from ..base.content import ContentModel
-from ..testbed.mcu import MCU
+from shepherd_core import fw_tools
+from shepherd_core.data_models.base.content import ContentModel
+from shepherd_core.data_models.testbed.mcu import MCU
+from shepherd_core.logger import logger
+from shepherd_core.testbed_client import tb_client
+
 from .firmware_datatype import FirmwareDType
 
 suffix_to_DType: dict = {

--- a/shepherd_core/shepherd_core/data_models/content/firmware.py
+++ b/shepherd_core/shepherd_core/data_models/content/firmware.py
@@ -4,6 +4,7 @@ TODO: should be more generalized - currently only supports msp & nRF
 """
 
 from pathlib import Path
+from typing import Annotated
 from typing import Optional
 from typing import TypedDict
 from typing import Union
@@ -11,7 +12,6 @@ from typing import Union
 from pydantic import StringConstraints
 from pydantic import model_validator
 from pydantic import validate_call
-from typing_extensions import Annotated
 from typing_extensions import Self
 from typing_extensions import Unpack
 

--- a/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
@@ -1,12 +1,11 @@
 """Generalized energy harvester data models."""
 
 from enum import Enum
+from typing import Annotated
 from typing import Optional
-from typing import Tuple
 
 from pydantic import Field
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ...commons import samplerate_sps_default
@@ -129,7 +128,7 @@ class VirtualHarvesterConfig(ContentModel, title="Config for the Harvester"):
             raise ValueError(msg)
         return num
 
-    def calc_timings_ms(self, *, for_emu: bool) -> Tuple[float, float]:
+    def calc_timings_ms(self, *, for_emu: bool) -> tuple[float, float]:
         """factor-in model-internal timing-constraints."""
         window_length = self.samples_n * (1 + self.wait_cycles)
         time_min_ms = (1 + self.wait_cycles) * 1_000 / samplerate_sps_default

--- a/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
@@ -10,7 +10,7 @@ from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
 
-from shepherd_core.commons import samplerate_sps_default
+from shepherd_core.commons import SAMPLERATE_SPS_DEFAULT
 from shepherd_core.data_models.base.calibration import CalibrationHarvester
 from shepherd_core.data_models.base.content import ContentModel
 from shepherd_core.data_models.base.shepherd import ShpModel
@@ -134,9 +134,9 @@ class VirtualHarvesterConfig(ContentModel, title="Config for the Harvester"):
     def calc_timings_ms(self, *, for_emu: bool) -> tuple[float, float]:
         """factor-in model-internal timing-constraints."""
         window_length = self.samples_n * (1 + self.wait_cycles)
-        time_min_ms = (1 + self.wait_cycles) * 1_000 / samplerate_sps_default
+        time_min_ms = (1 + self.wait_cycles) * 1_000 / SAMPLERATE_SPS_DEFAULT
         if for_emu:
-            window_ms = window_length * 1_000 / samplerate_sps_default
+            window_ms = window_length * 1_000 / SAMPLERATE_SPS_DEFAULT
             time_min_ms = max(time_min_ms, window_ms)
 
         interval_ms = min(max(self.interval_ms, time_min_ms), 1_000_000)
@@ -288,7 +288,7 @@ class HarvesterPRUConfig(ShpModel):
             voltage_step_uV=round(voltage_step_mV * 10**3),
             current_limit_nA=round(data.current_limit_uA * 10**3),
             setpoint_n8=round(min(255, data.setpoint_n * 2**8)),
-            interval_n=round(interval_ms * samplerate_sps_default * 1e-3),
-            duration_n=round(duration_ms * samplerate_sps_default * 1e-3),
+            interval_n=round(interval_ms * SAMPLERATE_SPS_DEFAULT * 1e-3),
+            duration_n=round(duration_ms * SAMPLERATE_SPS_DEFAULT * 1e-3),
             wait_cycles_n=data.wait_cycles,
         )

--- a/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
@@ -10,12 +10,13 @@ from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ...commons import samplerate_sps_default
-from ...logger import logger
-from ...testbed_client import tb_client
-from ..base.calibration import CalibrationHarvester
-from ..base.content import ContentModel
-from ..base.shepherd import ShpModel
+from shepherd_core.commons import samplerate_sps_default
+from shepherd_core.data_models.base.calibration import CalibrationHarvester
+from shepherd_core.data_models.base.content import ContentModel
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.logger import logger
+from shepherd_core.testbed_client import tb_client
+
 from .energy_environment import EnergyDType
 
 

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -7,11 +7,12 @@ from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ...commons import samplerate_sps_default
-from ...logger import logger
-from ...testbed_client import tb_client
-from ..base.content import ContentModel
-from ..base.shepherd import ShpModel
+from shepherd_core.commons import samplerate_sps_default
+from shepherd_core.data_models.base.content import ContentModel
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.logger import logger
+from shepherd_core.testbed_client import tb_client
+
 from .energy_environment import EnergyDType
 from .virtual_harvester import HarvesterPRUConfig
 from .virtual_harvester import VirtualHarvesterConfig

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -1,6 +1,7 @@
 """Generalized virtual source data models."""
 
 from typing import Annotated
+from typing import Any
 
 from pydantic import Field
 from pydantic import model_validator
@@ -112,7 +113,7 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         values, chain = tb_client.try_completing_model(cls.__name__, values)
         values = tb_client.fill_in_user_data(values)
         logger.debug("VSrc-Inheritances: %s", chain)

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
 
-from shepherd_core.commons import samplerate_sps_default
+from shepherd_core.commons import SAMPLERATE_SPS_DEFAULT
 from shepherd_core.data_models.base.content import ContentModel
 from shepherd_core.data_models.base.shepherd import ShpModel
 from shepherd_core.logger import logger
@@ -239,7 +239,7 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
         dV[uV] = constant[us/nF] * current[nA] = constant[us*V/nAs] * current[nA]
         """
         C_cap_uF = max(self.C_intermediate_uF, 0.001)
-        return int((10**3 * (2**28)) // (C_cap_uF * samplerate_sps_default))
+        return int((10**3 * (2**28)) // (C_cap_uF * SAMPLERATE_SPS_DEFAULT))
 
 
 u32 = Annotated[int, Field(ge=0, lt=2**32)]
@@ -314,7 +314,7 @@ class ConverterPRUConfig(ShpModel):
                 dtype_in, log_intermediate_node=log_intermediate_node
             ),
             interval_startup_delay_drain_n=round(
-                data.interval_startup_delay_drain_ms * samplerate_sps_default * 1e-3
+                data.interval_startup_delay_drain_ms * SAMPLERATE_SPS_DEFAULT * 1e-3
             ),
             V_input_max_uV=round(data.V_input_max_mV * 1e3),
             I_input_max_nA=round(data.I_input_max_mA * 1e6),
@@ -327,7 +327,7 @@ class ConverterPRUConfig(ShpModel):
             V_disable_output_threshold_uV=round(states["V_disable_output_threshold_mV"] * 1e3),
             dV_enable_output_uV=round(states["dV_enable_output_mV"] * 1e3),
             interval_check_thresholds_n=round(
-                data.interval_check_thresholds_ms * samplerate_sps_default * 1e-3
+                data.interval_check_thresholds_ms * SAMPLERATE_SPS_DEFAULT * 1e-3
             ),
             V_pwr_good_enable_threshold_uV=round(data.V_pwr_good_enable_threshold_mV * 1e3),
             V_pwr_good_disable_threshold_uV=round(data.V_pwr_good_disable_threshold_mV * 1e3),

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -1,10 +1,9 @@
 """Generalized virtual source data models."""
 
-from typing import List
+from typing import Annotated
 
 from pydantic import Field
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ...commons import samplerate_sps_default
@@ -19,8 +18,8 @@ from .virtual_harvester import VirtualHarvesterConfig
 # Custom Types
 LUT_SIZE: int = 12
 NormedNum = Annotated[float, Field(ge=0.0, le=1.0)]
-LUT1D = Annotated[List[NormedNum], Field(min_length=LUT_SIZE, max_length=LUT_SIZE)]
-LUT2D = Annotated[List[LUT1D], Field(min_length=LUT_SIZE, max_length=LUT_SIZE)]
+LUT1D = Annotated[list[NormedNum], Field(min_length=LUT_SIZE, max_length=LUT_SIZE)]
+LUT2D = Annotated[list[LUT1D], Field(min_length=LUT_SIZE, max_length=LUT_SIZE)]
 
 
 class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
@@ -244,13 +243,13 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
 u32 = Annotated[int, Field(ge=0, lt=2**32)]
 u8 = Annotated[int, Field(ge=0, lt=2**8)]
 lut_i = Annotated[
-    List[Annotated[List[u8], Field(min_length=LUT_SIZE, max_length=LUT_SIZE)]],
+    list[Annotated[list[u8], Field(min_length=LUT_SIZE, max_length=LUT_SIZE)]],
     Field(
         min_length=LUT_SIZE,
         max_length=LUT_SIZE,
     ),
 ]
-lut_o = Annotated[List[u32], Field(min_length=LUT_SIZE, max_length=LUT_SIZE)]
+lut_o = Annotated[list[u32], Field(min_length=LUT_SIZE, max_length=LUT_SIZE)]
 
 
 class ConverterPRUConfig(ShpModel):

--- a/shepherd_core/shepherd_core/data_models/experiment/experiment.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/experiment.py
@@ -70,8 +70,8 @@ class Experiment(ShpModel, title="Config of an Experiment"):
 
     @staticmethod
     def _validate_targets(configs: Iterable[TargetConfig]) -> None:
-        target_ids = []
-        custom_ids = []
+        target_ids: list[int] = []
+        custom_ids: list[int] = []
         for _config in configs:
             for _id in _config.target_IDs:
                 target_ids.append(_id)

--- a/shepherd_core/shepherd_core/data_models/experiment/experiment.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/experiment.py
@@ -13,13 +13,14 @@ from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ...version import version
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.content import SafeStr
-from ..base.shepherd import ShpModel
-from ..testbed.target import Target
-from ..testbed.testbed import Testbed
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.testbed.target import Target
+from shepherd_core.data_models.testbed.testbed import Testbed
+from shepherd_core.version import version
+
 from .observer_features import SystemLogging
 from .target_config import TargetConfig
 

--- a/shepherd_core/shepherd_core/data_models/experiment/experiment.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/experiment.py
@@ -1,9 +1,9 @@
 """Config for testbed experiments."""
 
+from collections.abc import Iterable
 from datetime import datetime
 from datetime import timedelta
-from typing import Iterable
-from typing import List
+from typing import Annotated
 from typing import Optional
 from typing import Union
 from uuid import uuid4
@@ -11,7 +11,6 @@ from uuid import uuid4
 from pydantic import UUID4
 from pydantic import Field
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ...version import version
@@ -54,7 +53,7 @@ class Experiment(ShpModel, title="Config of an Experiment"):
     abort_on_error: bool = False
 
     # targets
-    target_configs: Annotated[List[TargetConfig], Field(min_length=1, max_length=128)]
+    target_configs: Annotated[list[TargetConfig], Field(min_length=1, max_length=128)]
 
     # for debug-purposes and later comp-checks
     lib_ver: Optional[str] = version

--- a/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
@@ -11,8 +11,8 @@ from pydantic import PositiveFloat
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ..base.shepherd import ShpModel
-from ..testbed.gpio import GPIO
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.testbed.gpio import GPIO
 
 
 class PowerTracing(ShpModel, title="Config for Power-Tracing"):

--- a/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
@@ -26,7 +26,7 @@ class PowerTracing(ShpModel, title="Config for Power-Tracing"):
     #            this also includes current!
 
     # time
-    delay: timedelta = 0  # seconds
+    delay: timedelta = timedelta(seconds=0)
     duration: Optional[timedelta] = None  # till EOF
 
     # post-processing
@@ -64,7 +64,7 @@ class GpioTracing(ShpModel, title="Config for GPIO-Tracing"):
     # ⤷ TODO: list of GPIO to build mask, one of both should be internal / computed field
 
     # time
-    delay: timedelta = 0  # seconds
+    delay: timedelta = timedelta(seconds=0)
     duration: Optional[timedelta] = None  # till EOF
 
     # post-processing,

--- a/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
@@ -2,14 +2,13 @@
 
 from datetime import timedelta
 from enum import Enum
-from typing import List
+from typing import Annotated
 from typing import Optional
 
 import numpy as np
 from pydantic import Field
 from pydantic import PositiveFloat
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ..base.shepherd import ShpModel
@@ -61,7 +60,7 @@ class GpioTracing(ShpModel, title="Config for GPIO-Tracing"):
     # initial recording
     mask: Annotated[int, Field(ge=0, lt=2**10)] = 0b11_1111_1111  # all
     # ⤷ TODO: custom mask not implemented in PRU, ATM
-    gpios: Optional[Annotated[List[GPIO], Field(min_length=1, max_length=10)]] = None  # = all
+    gpios: Optional[Annotated[list[GPIO], Field(min_length=1, max_length=10)]] = None  # = all
     # ⤷ TODO: list of GPIO to build mask, one of both should be internal / computed field
 
     # time
@@ -125,7 +124,7 @@ class GpioActuation(ShpModel, title="Config for GPIO-Actuation"):
     # TODO: not implemented ATM - decide if pru control sys-gpio or
     # TODO: not implemented ATM - reverses pru-gpio (preferred if possible)
 
-    events: Annotated[List[GpioEvent], Field(min_length=1, max_length=1024)]
+    events: Annotated[list[GpioEvent], Field(min_length=1, max_length=1024)]
 
     def get_gpios(self) -> set:
         return {_ev.gpio for _ev in self.events}

--- a/shepherd_core/shepherd_core/data_models/experiment/target_config.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/target_config.py
@@ -1,11 +1,10 @@
 """Configuration related to Target Nodes (DuT)."""
 
-from typing import List
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ..base.content import IdInt
@@ -23,15 +22,15 @@ from .observer_features import PowerTracing
 class TargetConfig(ShpModel, title="Target Config"):
     """Configuration related to Target Nodes (DuT)."""
 
-    target_IDs: Annotated[List[IdInt], Field(min_length=1, max_length=128)]
-    custom_IDs: Optional[Annotated[List[IdInt16], Field(min_length=1, max_length=128)]] = None
+    target_IDs: Annotated[list[IdInt], Field(min_length=1, max_length=128)]
+    custom_IDs: Optional[Annotated[list[IdInt16], Field(min_length=1, max_length=128)]] = None
     # ⤷ will replace 'const uint16_t SHEPHERD_NODE_ID' in firmware
     #   if no custom ID is provided, the original ID of target is used
 
     energy_env: EnergyEnvironment  # alias: input
     virtual_source: VirtualSourceConfig = VirtualSourceConfig(name="neutral")
     target_delays: Optional[
-        Annotated[List[Annotated[int, Field(ge=0)]], Field(min_length=1, max_length=128)]
+        Annotated[list[Annotated[int, Field(ge=0)]], Field(min_length=1, max_length=128)]
     ] = None
     # ⤷ individual starting times -> allows to use the same environment
     # TODO: delays not used ATM

--- a/shepherd_core/shepherd_core/data_models/experiment/target_config.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/target_config.py
@@ -7,13 +7,14 @@ from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ..base.content import IdInt
-from ..base.shepherd import ShpModel
-from ..content.energy_environment import EnergyEnvironment
-from ..content.firmware import Firmware
-from ..content.virtual_source import VirtualSourceConfig
-from ..testbed.target import IdInt16
-from ..testbed.target import Target
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.content.energy_environment import EnergyEnvironment
+from shepherd_core.data_models.content.firmware import Firmware
+from shepherd_core.data_models.content.virtual_source import VirtualSourceConfig
+from shepherd_core.data_models.testbed.target import IdInt16
+from shepherd_core.data_models.testbed.target import Target
+
 from .observer_features import GpioActuation
 from .observer_features import GpioTracing
 from .observer_features import PowerTracing

--- a/shepherd_core/shepherd_core/data_models/task/__init__.py
+++ b/shepherd_core/shepherd_core/data_models/task/__init__.py
@@ -9,9 +9,10 @@ from typing import Union
 
 import yaml
 
-from ...logger import logger
-from ..base.shepherd import ShpModel
-from ..base.wrapper import Wrapper
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.base.wrapper import Wrapper
+from shepherd_core.logger import logger
+
 from .emulation import Compression
 from .emulation import EmulationTask
 from .firmware_mod import FirmwareModTask

--- a/shepherd_core/shepherd_core/data_models/task/__init__.py
+++ b/shepherd_core/shepherd_core/data_models/task/__init__.py
@@ -4,7 +4,6 @@ These models import externally from all other model-modules!
 """
 
 from pathlib import Path
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -74,7 +73,7 @@ def prepare_task(config: Union[ShpModel, Path, str], observer: Optional[str] = N
     return shp_wrap
 
 
-def extract_tasks(shp_wrap: Wrapper, *, no_task_sets: bool = True) -> List[ShpModel]:
+def extract_tasks(shp_wrap: Wrapper, *, no_task_sets: bool = True) -> list[ShpModel]:
     """Make the individual task-sets usable for each observer."""
     if shp_wrap.datatype == ObserverTasks.__name__:
         obt = ObserverTasks(**shp_wrap.parameters)

--- a/shepherd_core/shepherd_core/data_models/task/emulation.py
+++ b/shepherd_core/shepherd_core/data_models/task/emulation.py
@@ -111,9 +111,8 @@ class EmulationTask(ShpModel):
     @model_validator(mode="after")
     def post_validation(self) -> Self:
         # TODO: limit paths
-        has_time = self.time_start is not None
         time_now = datetime.now().astimezone()
-        if has_time and self.time_start < time_now:
+        if self.time_start is not None and self.time_start < time_now:
             msg = (
                 "Start-Time for Emulation can't be in the past "
                 f"('{self.time_start}' vs '{time_now}'."

--- a/shepherd_core/shepherd_core/data_models/task/emulation.py
+++ b/shepherd_core/shepherd_core/data_models/task/emulation.py
@@ -14,17 +14,17 @@ from pydantic import model_validator
 from pydantic import validate_call
 from typing_extensions import Self
 
-from ..base.content import IdInt
-from ..base.shepherd import ShpModel
-from ..base.timezone import local_tz
-from ..content.virtual_source import VirtualSourceConfig
-from ..experiment.experiment import Experiment
-from ..experiment.observer_features import GpioActuation
-from ..experiment.observer_features import GpioTracing
-from ..experiment.observer_features import PowerTracing
-from ..experiment.observer_features import SystemLogging
-from ..testbed import Testbed
-from ..testbed.cape import TargetPort
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.base.timezone import local_tz
+from shepherd_core.data_models.content.virtual_source import VirtualSourceConfig
+from shepherd_core.data_models.experiment.experiment import Experiment
+from shepherd_core.data_models.experiment.observer_features import GpioActuation
+from shepherd_core.data_models.experiment.observer_features import GpioTracing
+from shepherd_core.data_models.experiment.observer_features import PowerTracing
+from shepherd_core.data_models.experiment.observer_features import SystemLogging
+from shepherd_core.data_models.testbed import Testbed
+from shepherd_core.data_models.testbed.cape import TargetPort
 
 
 class Compression(str, Enum):

--- a/shepherd_core/shepherd_core/data_models/task/emulation.py
+++ b/shepherd_core/shepherd_core/data_models/task/emulation.py
@@ -5,13 +5,13 @@ from datetime import datetime
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
+from typing import Annotated
 from typing import Optional
 from typing import Union
 
 from pydantic import Field
 from pydantic import model_validator
 from pydantic import validate_call
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ..base.content import IdInt

--- a/shepherd_core/shepherd_core/data_models/task/firmware_mod.py
+++ b/shepherd_core/shepherd_core/data_models/task/firmware_mod.py
@@ -13,16 +13,16 @@ from pydantic import validate_call
 from typing_extensions import Self
 from typing_extensions import Unpack
 
-from ...logger import logger
-from ..base.content import IdInt
-from ..base.shepherd import ShpModel
-from ..content.firmware import Firmware
-from ..content.firmware import FirmwareDType
-from ..content.firmware import FirmwareStr
-from ..experiment.experiment import Experiment
-from ..testbed import Testbed
-from ..testbed.target import IdInt16
-from ..testbed.target import MCUPort
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.content.firmware import Firmware
+from shepherd_core.data_models.content.firmware import FirmwareDType
+from shepherd_core.data_models.content.firmware import FirmwareStr
+from shepherd_core.data_models.experiment.experiment import Experiment
+from shepherd_core.data_models.testbed import Testbed
+from shepherd_core.data_models.testbed.target import IdInt16
+from shepherd_core.data_models.testbed.target import MCUPort
+from shepherd_core.logger import logger
 
 
 class FirmwareModTask(ShpModel):

--- a/shepherd_core/shepherd_core/data_models/task/firmware_mod.py
+++ b/shepherd_core/shepherd_core/data_models/task/firmware_mod.py
@@ -2,6 +2,7 @@
 
 import copy
 from pathlib import Path
+from typing import Annotated
 from typing import Optional
 from typing import TypedDict
 from typing import Union
@@ -9,7 +10,6 @@ from typing import Union
 from pydantic import Field
 from pydantic import model_validator
 from pydantic import validate_call
-from typing_extensions import Annotated
 from typing_extensions import Self
 from typing_extensions import Unpack
 

--- a/shepherd_core/shepherd_core/data_models/task/harvest.py
+++ b/shepherd_core/shepherd_core/data_models/task/harvest.py
@@ -3,11 +3,11 @@
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ..base.shepherd import ShpModel

--- a/shepherd_core/shepherd_core/data_models/task/harvest.py
+++ b/shepherd_core/shepherd_core/data_models/task/harvest.py
@@ -10,11 +10,12 @@ from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ..base.shepherd import ShpModel
-from ..base.timezone import local_tz
-from ..content.virtual_harvester import VirtualHarvesterConfig
-from ..experiment.observer_features import PowerTracing
-from ..experiment.observer_features import SystemLogging
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.base.timezone import local_tz
+from shepherd_core.data_models.content.virtual_harvester import VirtualHarvesterConfig
+from shepherd_core.data_models.experiment.observer_features import PowerTracing
+from shepherd_core.data_models.experiment.observer_features import SystemLogging
+
 from .emulation import Compression
 
 

--- a/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
+++ b/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
@@ -8,11 +8,12 @@ from typing import Optional
 from pydantic import validate_call
 from typing_extensions import Self
 
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.shepherd import ShpModel
-from ..experiment.experiment import Experiment
-from ..testbed.testbed import Testbed
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.experiment.experiment import Experiment
+from shepherd_core.data_models.testbed.testbed import Testbed
+
 from .emulation import EmulationTask
 from .firmware_mod import FirmwareModTask
 from .programming import ProgrammingTask

--- a/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
+++ b/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
-from typing import List
 from typing import Optional
 
 from pydantic import validate_call
@@ -78,7 +77,7 @@ class ObserverTasks(ShpModel):
             emulation=EmulationTask.from_xp(xp, tb, tgt_id, root_path),
         )
 
-    def get_tasks(self) -> List[ShpModel]:
+    def get_tasks(self) -> list[ShpModel]:
         task_names = ["fw1_mod", "fw2_mod", "fw1_prog", "fw2_prog", "emulation"]
         tasks = []
 

--- a/shepherd_core/shepherd_core/data_models/task/programming.py
+++ b/shepherd_core/shepherd_core/data_models/task/programming.py
@@ -2,12 +2,12 @@
 
 import copy
 from pathlib import Path
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import model_validator
 from pydantic import validate_call
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ..base.content import IdInt

--- a/shepherd_core/shepherd_core/data_models/task/programming.py
+++ b/shepherd_core/shepherd_core/data_models/task/programming.py
@@ -10,16 +10,16 @@ from pydantic import model_validator
 from pydantic import validate_call
 from typing_extensions import Self
 
-from ..base.content import IdInt
-from ..base.content import SafeStr
-from ..base.shepherd import ShpModel
-from ..content.firmware import suffix_to_DType
-from ..content.firmware_datatype import FirmwareDType
-from ..experiment.experiment import Experiment
-from ..testbed.cape import TargetPort
-from ..testbed.mcu import ProgrammerProtocol
-from ..testbed.target import MCUPort
-from ..testbed.testbed import Testbed
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.content.firmware import suffix_to_DType
+from shepherd_core.data_models.content.firmware_datatype import FirmwareDType
+from shepherd_core.data_models.experiment.experiment import Experiment
+from shepherd_core.data_models.testbed.cape import TargetPort
+from shepherd_core.data_models.testbed.mcu import ProgrammerProtocol
+from shepherd_core.data_models.testbed.target import MCUPort
+from shepherd_core.data_models.testbed.testbed import Testbed
 
 
 class ProgrammingTask(ShpModel):

--- a/shepherd_core/shepherd_core/data_models/task/testbed_tasks.py
+++ b/shepherd_core/shepherd_core/data_models/task/testbed_tasks.py
@@ -7,11 +7,12 @@ from pydantic import Field
 from pydantic import validate_call
 from typing_extensions import Self
 
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.shepherd import ShpModel
-from ..experiment.experiment import Experiment
-from ..testbed.testbed import Testbed
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.experiment.experiment import Experiment
+from shepherd_core.data_models.testbed.testbed import Testbed
+
 from .observer_tasks import ObserverTasks
 
 

--- a/shepherd_core/shepherd_core/data_models/task/testbed_tasks.py
+++ b/shepherd_core/shepherd_core/data_models/task/testbed_tasks.py
@@ -1,11 +1,10 @@
 """Collection of tasks for all observers included in experiment."""
 
-from typing import List
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import validate_call
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ..base.content import IdInt
@@ -20,7 +19,7 @@ class TestbedTasks(ShpModel):
     """Collection of tasks for all observers included in experiment."""
 
     name: NameStr
-    observer_tasks: Annotated[List[ObserverTasks], Field(min_length=1, max_length=128)]
+    observer_tasks: Annotated[list[ObserverTasks], Field(min_length=1, max_length=128)]
 
     # POST PROCESS
     email_results: bool = False

--- a/shepherd_core/shepherd_core/data_models/testbed/cape.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/cape.py
@@ -3,6 +3,7 @@
 from datetime import date
 from datetime import datetime
 from enum import Enum
+from typing import Any
 from typing import Optional
 from typing import Union
 
@@ -42,6 +43,6 @@ class Cape(ShpModel, title="Shepherd-Cape"):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         values, _ = tb_client.try_completing_model(cls.__name__, values)
         return values

--- a/shepherd_core/shepherd_core/data_models/testbed/cape.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/cape.py
@@ -10,11 +10,11 @@ from typing import Union
 from pydantic import Field
 from pydantic import model_validator
 
-from ...testbed_client import tb_client
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.content import SafeStr
-from ..base.shepherd import ShpModel
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.testbed_client import tb_client
 
 
 class TargetPort(str, Enum):

--- a/shepherd_core/shepherd_core/data_models/testbed/gpio.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/gpio.py
@@ -10,11 +10,11 @@ from pydantic import StringConstraints
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ...testbed_client import tb_client
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.content import SafeStr
-from ..base.shepherd import ShpModel
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.testbed_client import tb_client
 
 
 class Direction(str, Enum):

--- a/shepherd_core/shepherd_core/data_models/testbed/gpio.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/gpio.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from typing import Annotated
+from typing import Any
 from typing import Optional
 
 from pydantic import Field
@@ -45,7 +46,7 @@ class GPIO(ShpModel, title="GPIO of Observer Node"):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         values, _ = tb_client.try_completing_model(cls.__name__, values)
         return values
 

--- a/shepherd_core/shepherd_core/data_models/testbed/gpio.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/gpio.py
@@ -1,12 +1,12 @@
 """meta-data representation of a testbed-component (physical object)."""
 
 from enum import Enum
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import StringConstraints
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ...testbed_client import tb_client

--- a/shepherd_core/shepherd_core/data_models/testbed/mcu.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/mcu.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from typing import Annotated
+from typing import Any
 from typing import Optional
 
 from pydantic import Field
@@ -45,6 +46,6 @@ class MCU(ShpModel, title="Microcontroller of the Target Node"):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         values, _ = tb_client.try_completing_model(cls.__name__, values)
         return values

--- a/shepherd_core/shepherd_core/data_models/testbed/mcu.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/mcu.py
@@ -1,11 +1,11 @@
 """meta-data representation of a testbed-component (physical object)."""
 
 from enum import Enum
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import model_validator
-from typing_extensions import Annotated
 
 from ...testbed_client import tb_client
 from ..base.content import IdInt

--- a/shepherd_core/shepherd_core/data_models/testbed/mcu.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/mcu.py
@@ -8,11 +8,11 @@ from typing import Optional
 from pydantic import Field
 from pydantic import model_validator
 
-from ...testbed_client import tb_client
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.content import SafeStr
-from ..base.shepherd import ShpModel
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.testbed_client import tb_client
 
 
 class ProgrammerProtocol(str, Enum):

--- a/shepherd_core/shepherd_core/data_models/testbed/observer.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/observer.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from typing import Annotated
+from typing import Any
 from typing import Optional
 
 from pydantic import Field
@@ -56,7 +57,7 @@ class Observer(ShpModel, title="Shepherd-Sheep"):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         values, _ = tb_client.try_completing_model(cls.__name__, values)
         return values
 

--- a/shepherd_core/shepherd_core/data_models/testbed/observer.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/observer.py
@@ -11,11 +11,12 @@ from pydantic import StringConstraints
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ...testbed_client import tb_client
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.content import SafeStr
-from ..base.shepherd import ShpModel
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.testbed_client import tb_client
+
 from .cape import Cape
 from .cape import TargetPort
 from .target import Target

--- a/shepherd_core/shepherd_core/data_models/testbed/observer.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/observer.py
@@ -1,13 +1,13 @@
 """meta-data representation of a testbed-component (physical object)."""
 
 from datetime import datetime
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import IPvAnyAddress
 from pydantic import StringConstraints
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ...testbed_client import tb_client

--- a/shepherd_core/shepherd_core/data_models/testbed/target.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/target.py
@@ -9,11 +9,12 @@ from typing import Union
 from pydantic import Field
 from pydantic import model_validator
 
-from ...testbed_client import tb_client
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.content import SafeStr
-from ..base.shepherd import ShpModel
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.testbed_client import tb_client
+
 from .mcu import MCU
 
 IdInt16 = Annotated[int, Field(ge=0, lt=2**16)]

--- a/shepherd_core/shepherd_core/data_models/testbed/target.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/target.py
@@ -1,12 +1,12 @@
 """meta-data representation of a testbed-component (physical object)."""
 
 from datetime import datetime
+from typing import Annotated
 from typing import Optional
 from typing import Union
 
 from pydantic import Field
 from pydantic import model_validator
-from typing_extensions import Annotated
 
 from ...testbed_client import tb_client
 from ..base.content import IdInt

--- a/shepherd_core/shepherd_core/data_models/testbed/target.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/target.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from typing import Annotated
+from typing import Any
 from typing import Optional
 from typing import Union
 
@@ -45,7 +46,7 @@ class Target(ShpModel, title="Target Node (DuT)"):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         values, _ = tb_client.try_completing_model(cls.__name__, values)
 
         # post correction

--- a/shepherd_core/shepherd_core/data_models/testbed/testbed.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/testbed.py
@@ -2,13 +2,12 @@
 
 from datetime import timedelta
 from pathlib import Path
-from typing import List
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import HttpUrl
 from pydantic import model_validator
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ... import logger
@@ -30,7 +29,7 @@ class Testbed(ShpModel):
 
     url: Optional[HttpUrl] = None
 
-    observers: Annotated[List[Observer], Field(min_length=1, max_length=128)]
+    observers: Annotated[list[Observer], Field(min_length=1, max_length=128)]
 
     shared_storage: bool = True
     data_on_server: Path

--- a/shepherd_core/shepherd_core/data_models/testbed/testbed.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/testbed.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 from pathlib import Path
 from typing import Annotated
+from typing import Any
 from typing import Optional
 
 from pydantic import Field
@@ -10,8 +11,9 @@ from pydantic import HttpUrl
 from pydantic import model_validator
 from typing_extensions import Self
 
-from ... import logger
-from ...testbed_client import tb_client
+from shepherd_core.logger import logger
+from shepherd_core.testbed_client import tb_client
+
 from ..base.content import IdInt
 from ..base.content import NameStr
 from ..base.content import SafeStr
@@ -41,7 +43,7 @@ class Testbed(ShpModel):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         # allow instantiating an empty Testbed
         #   -> query the first (and only) entry of client
         if len(values) == 0:

--- a/shepherd_core/shepherd_core/data_models/testbed/testbed.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/testbed.py
@@ -11,13 +11,13 @@ from pydantic import HttpUrl
 from pydantic import model_validator
 from typing_extensions import Self
 
+from shepherd_core.data_models.base.content import IdInt
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
 from shepherd_core.logger import logger
 from shepherd_core.testbed_client import tb_client
 
-from ..base.content import IdInt
-from ..base.content import NameStr
-from ..base.content import SafeStr
-from ..base.shepherd import ShpModel
 from .observer import Observer
 
 

--- a/shepherd_core/shepherd_core/decoder_waveform/uart.py
+++ b/shepherd_core/shepherd_core/decoder_waveform/uart.py
@@ -208,10 +208,10 @@ class Uart:
         if self.events_symbols is not None:
             return self.events_symbols
 
-        pos_df = None
-        symbol = 0
-        t_start = None
-        content = []
+        pos_df: Optional[int] = None
+        symbol: int = 0
+        t_start: Optional[float] = None
+        content: list = []
 
         for time, value, steps in self.events_sig:
             if steps > self.frame_length:

--- a/shepherd_core/shepherd_core/decoder_waveform/uart.py
+++ b/shepherd_core/shepherd_core/decoder_waveform/uart.py
@@ -28,7 +28,7 @@ from typing import Union
 
 import numpy as np
 
-from ..logger import logger
+from shepherd_core.logger import logger
 
 
 class Parity(str, Enum):

--- a/shepherd_core/shepherd_core/fw_tools/converter.py
+++ b/shepherd_core/shepherd_core/fw_tools/converter.py
@@ -85,10 +85,10 @@ def extract_firmware(data: Union[str, Path], data_type: FirmwareDType, file_path
     - base64-string will be transformed to file
     - if data is a path the file will be copied to the destination.
     """
-    if data_type == FirmwareDType.base64_elf:
+    if data_type == FirmwareDType.base64_elf and isinstance(data, str):
         file = file_path.with_suffix(".elf")
         base64_to_file(data, file)
-    elif data_type == FirmwareDType.base64_hex:
+    elif data_type == FirmwareDType.base64_hex and isinstance(data, str):
         file = file_path.with_suffix(".hex")
         base64_to_file(data, file)
     elif isinstance(data, (Path, str)):

--- a/shepherd_core/shepherd_core/fw_tools/converter.py
+++ b/shepherd_core/shepherd_core/fw_tools/converter.py
@@ -9,7 +9,8 @@ from typing import Union
 import zstandard as zstd
 from pydantic import validate_call
 
-from ..data_models.content.firmware_datatype import FirmwareDType
+from shepherd_core.data_models.content.firmware_datatype import FirmwareDType
+
 from .converter_elf import elf_to_hex
 from .validation import is_elf
 from .validation import is_hex

--- a/shepherd_core/shepherd_core/fw_tools/patcher.py
+++ b/shepherd_core/shepherd_core/fw_tools/patcher.py
@@ -7,8 +7,8 @@ from typing import Optional
 from pydantic import Field
 from pydantic import validate_call
 
-from shepherd_core.commons import uid_len_default
-from shepherd_core.commons import uid_str_default
+from shepherd_core.commons import UID_NAME
+from shepherd_core.commons import UID_SIZE
 from shepherd_core.logger import logger
 
 from .validation import is_elf
@@ -50,7 +50,7 @@ def find_symbol(file_elf: Path, symbol: str) -> bool:
 
 
 @validate_call
-def read_symbol(file_elf: Path, symbol: str, length: int = uid_len_default) -> Optional[int]:
+def read_symbol(file_elf: Path, symbol: str, length: int = UID_SIZE) -> Optional[int]:
     """Read value of symbol in ELF-File.
 
     Will be interpreted as int.
@@ -68,7 +68,7 @@ def read_symbol(file_elf: Path, symbol: str, length: int = uid_len_default) -> O
 
 def read_uid(file_elf: Path) -> Optional[int]:
     """Read value of UID-symbol for shepherd testbed."""
-    return read_symbol(file_elf, symbol=uid_str_default, length=uid_len_default)
+    return read_symbol(file_elf, symbol=UID_NAME, length=UID_SIZE)
 
 
 def read_arch(file_elf: Path) -> Optional[str]:
@@ -88,7 +88,7 @@ def read_arch(file_elf: Path) -> Optional[str]:
 def modify_symbol_value(
     file_elf: Path,
     symbol: str,
-    value: Annotated[int, Field(ge=0, lt=2 ** (8 * uid_len_default))],
+    value: Annotated[int, Field(ge=0, lt=2 ** (8 * UID_SIZE))],
     *,
     overwrite: bool = False,
 ) -> Optional[Path]:
@@ -106,10 +106,10 @@ def modify_symbol_value(
         raise RuntimeError(elf_error_text)
     elf = ELF(path=file_elf)
     addr = elf.symbols[symbol]
-    value_raw = elf.read(address=addr, count=uid_len_default)[-uid_len_default:]
+    value_raw = elf.read(address=addr, count=UID_SIZE)[-UID_SIZE:]
     # ⤷ cutting needed -> msp produces 4b instead of 2
     value_old = int.from_bytes(bytes=value_raw, byteorder=elf.endian, signed=False)
-    value_raw = value.to_bytes(length=uid_len_default, byteorder=elf.endian, signed=False)
+    value_raw = value.to_bytes(length=UID_SIZE, byteorder=elf.endian, signed=False)
 
     try:
         elf.write(address=addr, data=value_raw)
@@ -132,4 +132,4 @@ def modify_symbol_value(
 
 def modify_uid(file_elf: Path, value: int) -> Optional[Path]:
     """Replace value of UID-symbol for shepherd testbed."""
-    return modify_symbol_value(file_elf, symbol=uid_str_default, value=value, overwrite=True)
+    return modify_symbol_value(file_elf, symbol=UID_NAME, value=value, overwrite=True)

--- a/shepherd_core/shepherd_core/fw_tools/patcher.py
+++ b/shepherd_core/shepherd_core/fw_tools/patcher.py
@@ -109,16 +109,14 @@ def modify_symbol_value(
     # ⤷ cutting needed -> msp produces 4b instead of 2
     value_old = int.from_bytes(bytes=value_raw, byteorder=elf.endian, signed=False)
     value_raw = value.to_bytes(length=uid_len_default, byteorder=elf.endian, signed=False)
+
     try:
         elf.write(address=addr, data=value_raw)
     except AttributeError:
         logger.warning("ELF-Modifier failed @%s for symbol '%s'", f"0x{addr:X}", symbol)
         return None
-    if overwrite:
-        file_new = file_elf
-    else:
-        file_new = file_elf.with_name(file_elf.stem + "_" + str(value) + file_elf.suffix)
-        # could be simplified, but py3.8-- doesn't know .with_stem()
+
+    file_new = file_elf if overwrite else file_elf.with_stem(file_elf.stem + "_" + str(value))
     elf.save(path=file_new)
     elf.close()
     logger.debug(

--- a/shepherd_core/shepherd_core/fw_tools/patcher.py
+++ b/shepherd_core/shepherd_core/fw_tools/patcher.py
@@ -1,11 +1,11 @@
 """Read and modify symbols in ELF-files."""
 
 from pathlib import Path
+from typing import Annotated
 from typing import Optional
 
 from pydantic import Field
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 from ..commons import uid_len_default
 from ..commons import uid_str_default

--- a/shepherd_core/shepherd_core/fw_tools/patcher.py
+++ b/shepherd_core/shepherd_core/fw_tools/patcher.py
@@ -7,9 +7,10 @@ from typing import Optional
 from pydantic import Field
 from pydantic import validate_call
 
-from ..commons import uid_len_default
-from ..commons import uid_str_default
-from ..logger import logger
+from shepherd_core.commons import uid_len_default
+from shepherd_core.commons import uid_str_default
+from shepherd_core.logger import logger
+
 from .validation import is_elf
 
 try:

--- a/shepherd_core/shepherd_core/fw_tools/validation.py
+++ b/shepherd_core/shepherd_core/fw_tools/validation.py
@@ -12,8 +12,9 @@ from intelhex import IntelHex
 from intelhex import IntelHexError
 from pydantic import validate_call
 
-from ..data_models.content.firmware_datatype import FirmwareDType
-from ..logger import logger
+from shepherd_core.data_models.content.firmware_datatype import FirmwareDType
+from shepherd_core.logger import logger
+
 from .converter_elf import elf_to_hex
 
 try:

--- a/shepherd_core/shepherd_core/inventory/__init__.py
+++ b/shepherd_core/shepherd_core/inventory/__init__.py
@@ -9,10 +9,9 @@ This will collect:
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
-from typing import List
+from typing import Annotated
 
 from pydantic import Field
-from typing_extensions import Annotated
 from typing_extensions import Self
 
 from ..data_models import ShpModel
@@ -55,7 +54,7 @@ class Inventory(PythonInventory, SystemInventory, TargetInventory):
 class InventoryList(ShpModel):
     """Collection of inventories for several devices."""
 
-    elements: Annotated[List[Inventory], Field(min_length=1)]
+    elements: Annotated[list[Inventory], Field(min_length=1)]
 
     def to_csv(self, path: Path) -> None:
         """Generate a CSV.
@@ -82,8 +81,8 @@ class InventoryList(ShpModel):
             if (_e.created.timestamp() - ts_earl) > 10:
                 warnings["time_delta"] = f"[{self.hostname}] time-sync has failed"
 
-        # turn  Dict[hostname][type] = val
-        # to    Dict[type][val] = List[hostnames]
+        # turn  dict[hostname][type] = val
+        # to    dict[type][val] = list[hostnames]
         _inp = {
             _e.hostname: _e.model_dump(exclude_unset=True, exclude_defaults=True)
             for _e in self.elements

--- a/shepherd_core/shepherd_core/inventory/__init__.py
+++ b/shepherd_core/shepherd_core/inventory/__init__.py
@@ -14,7 +14,8 @@ from typing import Annotated
 from pydantic import Field
 from typing_extensions import Self
 
-from ..data_models import ShpModel
+from shepherd_core.data_models import ShpModel
+
 from .python import PythonInventory
 from .system import SystemInventory
 from .target import TargetInventory

--- a/shepherd_core/shepherd_core/inventory/python.py
+++ b/shepherd_core/shepherd_core/inventory/python.py
@@ -8,7 +8,7 @@ from typing import Optional
 from pydantic import ConfigDict
 from typing_extensions import Self
 
-from ..data_models import ShpModel
+from shepherd_core.data_models import ShpModel
 
 
 class PythonInventory(ShpModel):

--- a/shepherd_core/shepherd_core/inventory/system.py
+++ b/shepherd_core/shepherd_core/inventory/system.py
@@ -29,7 +29,7 @@ class SystemInventory(ShpModel):
     uptime: PositiveInt
     # ⤷ seconds
     timestamp: datetime
-    # time_delta: timedelta = timedelta(0)  # noqa: ERA001
+    # time_delta: timedelta = timedelta(seconds=0)  # noqa: ERA001
     # ⤷ lag behind earliest observer, TODO: wrong place
 
     system: str

--- a/shepherd_core/shepherd_core/inventory/system.py
+++ b/shepherd_core/shepherd_core/inventory/system.py
@@ -5,7 +5,6 @@ import subprocess
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import List
 from typing import Optional
 
 from typing_extensions import Self
@@ -49,8 +48,8 @@ class SystemInventory(ShpModel):
     #   ip IPvAnyAddress
     #   mac MACStr
 
-    fs_root: List[str] = None
-    beagle: List[str] = None
+    fs_root: list[str] = None
+    beagle: list[str] = None
 
     model_config = ConfigDict(str_min_length=0)
 

--- a/shepherd_core/shepherd_core/inventory/system.py
+++ b/shepherd_core/shepherd_core/inventory/system.py
@@ -9,8 +9,8 @@ from typing import Optional
 
 from typing_extensions import Self
 
-from ..data_models.base.timezone import local_now
-from ..logger import logger
+from shepherd_core.data_models.base.timezone import local_now
+from shepherd_core.logger import logger
 
 try:
     import psutil
@@ -20,7 +20,7 @@ except ImportError:
 from pydantic import ConfigDict
 from pydantic.types import PositiveInt
 
-from ..data_models import ShpModel
+from shepherd_core.data_models import ShpModel
 
 
 class SystemInventory(ShpModel):

--- a/shepherd_core/shepherd_core/inventory/system.py
+++ b/shepherd_core/shepherd_core/inventory/system.py
@@ -3,8 +3,12 @@
 import platform
 import subprocess
 import time
+from collections.abc import Mapping
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
+from types import MappingProxyType
+from typing import Any
 from typing import Optional
 
 from typing_extensions import Self
@@ -43,13 +47,13 @@ class SystemInventory(ShpModel):
 
     hostname: str
 
-    interfaces: dict = {}  # noqa: RUF012
+    interfaces: Mapping[str, Any] = MappingProxyType({})
     # ⤷ tuple with
     #   ip IPvAnyAddress
     #   mac MACStr
 
-    fs_root: list[str] = None
-    beagle: list[str] = None
+    fs_root: Sequence[str] = ()
+    beagle: Sequence[str] = ()
 
     model_config = ConfigDict(str_min_length=0)
 

--- a/shepherd_core/shepherd_core/inventory/target.py
+++ b/shepherd_core/shepherd_core/inventory/target.py
@@ -5,7 +5,7 @@ from typing import Optional
 from pydantic import ConfigDict
 from typing_extensions import Self
 
-from ..data_models import ShpModel
+from shepherd_core.data_models import ShpModel
 
 
 class TargetInventory(ShpModel):

--- a/shepherd_core/shepherd_core/inventory/target.py
+++ b/shepherd_core/shepherd_core/inventory/target.py
@@ -1,5 +1,6 @@
 """Hardware related inventory model."""
 
+from collections.abc import Sequence
 from typing import Optional
 
 from pydantic import ConfigDict
@@ -12,7 +13,7 @@ class TargetInventory(ShpModel):
     """Hardware related inventory model."""
 
     cape: Optional[str] = None
-    targets: list[str] = []  # noqa: RUF012
+    targets: Sequence[str] = ()
 
     model_config = ConfigDict(str_min_length=0)
 

--- a/shepherd_core/shepherd_core/inventory/target.py
+++ b/shepherd_core/shepherd_core/inventory/target.py
@@ -1,6 +1,5 @@
 """Hardware related inventory model."""
 
-from typing import List
 from typing import Optional
 
 from pydantic import ConfigDict
@@ -13,7 +12,7 @@ class TargetInventory(ShpModel):
     """Hardware related inventory model."""
 
     cape: Optional[str] = None
-    targets: List[str] = []  # noqa: RUF012
+    targets: list[str] = []  # noqa: RUF012
 
     model_config = ConfigDict(str_min_length=0)
 

--- a/shepherd_core/shepherd_core/logger.py
+++ b/shepherd_core/shepherd_core/logger.py
@@ -33,8 +33,8 @@ def set_log_verbose_level(log_: Union[logging.Logger, logging.Handler], verbose:
     if verbose < 3:
         # reduce log-overhead when not debugging, also more user-friendly exceptions
         logging._srcfile = None  # noqa: SLF001
-        logging.logThreads = 0
-        logging.logProcesses = 0
+        logging.logThreads = False
+        logging.logProcesses = False
 
     if verbose > 2:
         chromalog.basicConfig(format="%(name)s %(levelname)s: %(message)s")

--- a/shepherd_core/shepherd_core/reader.py
+++ b/shepherd_core/shepherd_core/reader.py
@@ -12,11 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Dict
-from typing import Generator
-from typing import List
 from typing import Optional
-from typing import Type
 from typing import Union
 
 import h5py
@@ -33,6 +29,7 @@ from .data_models.content.energy_environment import EnergyDType
 from .decoder_waveform import Uart
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from types import TracebackType
 
 
@@ -155,7 +152,7 @@ class Reader:
 
     def __exit__(
         self,
-        typ: Optional[Type[BaseException]] = None,
+        typ: Optional[type[BaseException]] = None,
         exc: Optional[BaseException] = None,
         tb: Optional[TracebackType] = None,
         extra_arg: int = 0,
@@ -254,7 +251,7 @@ class Reader:
             return self.h5file.attrs["mode"]
         return ""
 
-    def get_config(self) -> Dict:
+    def get_config(self) -> dict:
         if "config" in self.h5file["data"].attrs:
             return yaml.safe_load(self.h5file["data"].attrs["config"])
         return {}
@@ -478,7 +475,7 @@ class Reader:
 
     def _dset_statistics(
         self, dset: h5py.Dataset, cal: Optional[CalibrationPair] = None
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """Create basic stats for a provided dataset.
 
         :param dset: dataset to evaluate
@@ -511,7 +508,7 @@ class Reader:
         if len(stats_list) < 1:
             return {}
         stats_nd = np.stack(stats_list)
-        stats: Dict[str, float] = {
+        stats: dict[str, float] = {
             # TODO: wrong calculation for ndim-datasets with n>1
             "mean": float(stats_nd[:, 0].mean()),
             "min": float(stats_nd[:, 1].min()),
@@ -521,7 +518,7 @@ class Reader:
         }
         return stats
 
-    def _data_timediffs(self) -> List[float]:
+    def _data_timediffs(self) -> list[float]:
         """Calculate list of unique time-deltas [s] between buffers.
 
         Optimized version that only looks at the start of each buffer.
@@ -583,7 +580,7 @@ class Reader:
         node: Union[h5py.Dataset, h5py.Group, None] = None,
         *,
         minimal: bool = False,
-    ) -> Dict[str, dict]:
+    ) -> dict[str, dict]:
         """Recursive FN to capture the structure of the file.
 
         :param node: starting node, leave free to go through whole file
@@ -594,7 +591,7 @@ class Reader:
             self._refresh_file_stats()
             return self.get_metadata(self.h5file, minimal=minimal)
 
-        metadata: Dict[str, dict] = {}
+        metadata: dict[str, dict] = {}
         if isinstance(node, h5py.Dataset) and not minimal:
             metadata["_dataset_info"] = {
                 "datatype": str(node.dtype),
@@ -616,7 +613,7 @@ class Reader:
                 with contextlib.suppress(yaml.YAMLError):
                     attr_value = yaml.safe_load(attr_value)
             elif "int" in str(type(attr_value)):
-                # TODO: why not isinstance? can it be List[int] other complex type?
+                # TODO: why not isinstance? can it be list[int] other complex type?
                 attr_value = int(attr_value)
             else:
                 attr_value = float(attr_value)
@@ -675,7 +672,7 @@ class Reader:
         return data != data_1
 
     def gpio_to_waveforms(self, name: Optional[str] = None) -> dict:
-        waveforms: Dict[str, np.ndarray] = {}
+        waveforms: dict[str, np.ndarray] = {}
         if "gpio" not in self.h5file:
             return waveforms
 

--- a/shepherd_core/shepherd_core/reader.py
+++ b/shepherd_core/shepherd_core/reader.py
@@ -57,14 +57,11 @@ class Reader:
     @validate_call
     def __init__(
         self,
-        file_path: Optional[Path],
+        file_path: Path,
         *,
-        verbose: Optional[bool] = True,
+        verbose: bool = True,
     ) -> None:
-        if not hasattr(self, "file_path"):
-            self.file_path: Optional[Path] = None
-            if isinstance(file_path, (Path, str)):
-                self.file_path = Path(file_path).resolve()
+        self.file_path: Path = file_path.resolve()
 
         if not hasattr(self, "_logger"):
             self._logger: logging.Logger = logging.getLogger("SHPCore.Reader")
@@ -111,8 +108,6 @@ class Reader:
                     self.file_path.name,
                 )
 
-        if not isinstance(self.file_path, Path):
-            raise TypeError("Provide a valid Path-Object to Base-Reader.file_path!")
         if not isinstance(self.h5file, h5py.File):
             raise TypeError("Type of opened file is not h5py.File, for %s", self.file_path.name)
 

--- a/shepherd_core/shepherd_core/reader.py
+++ b/shepherd_core/shepherd_core/reader.py
@@ -111,6 +111,8 @@ class Reader:
                     self.file_path.name,
                 )
 
+        if not isinstance(self.file_path, Path):
+            raise TypeError("Provide a valid Path-Object to Base-Reader.file_path!")
         if not isinstance(self.h5file, h5py.File):
             raise TypeError("Type of opened file is not h5py.File, for %s", self.file_path.name)
 

--- a/shepherd_core/shepherd_core/testbed_client/client_abc_fix.py
+++ b/shepherd_core/shepherd_core/testbed_client/client_abc_fix.py
@@ -17,6 +17,7 @@ TODO: Comfort functions missing
 
 from abc import ABC
 from abc import abstractmethod
+from typing import Any
 from typing import Optional
 
 from ..data_models.base.shepherd import ShpModel
@@ -53,11 +54,15 @@ class AbcClient(ABC):
         pass
 
     @abstractmethod
-    def try_inheritance(self, model_type: str, values: dict) -> tuple[dict, list]:
+    def try_inheritance(
+        self, model_type: str, values: dict[str, Any]
+    ) -> tuple[dict[str, Any], list[str]]:
         # TODO: maybe internal? yes
         pass
 
-    def try_completing_model(self, model_type: str, values: dict) -> tuple[dict, list]:
+    def try_completing_model(
+        self, model_type: str, values: dict[str, Any]
+    ) -> tuple[dict[str, Any], list[str]]:
         """Init by name/id, for none existing instances raise Exception.
 
         This is the main entry-point for querying a model (used be the core-lib).
@@ -72,7 +77,7 @@ class AbcClient(ABC):
         return self.try_inheritance(model_type, values)
 
     @abstractmethod
-    def fill_in_user_data(self, values: dict) -> dict:
+    def fill_in_user_data(self, values: dict[str, Any]) -> dict[str, Any]:
         # TODO: is it really helpful and needed?
         pass
 
@@ -107,10 +112,12 @@ class FixturesClient(AbcClient):
             return self._fixtures[model_type].query_name(name)
         raise ValueError("Query needs either uid or name of object")
 
-    def try_inheritance(self, model_type: str, values: dict) -> tuple[dict, list]:
+    def try_inheritance(
+        self, model_type: str, values: dict[str, Any]
+    ) -> tuple[dict[str, Any], list[str]]:
         return self._fixtures[model_type].inheritance(values)
 
-    def fill_in_user_data(self, values: dict) -> dict:
+    def fill_in_user_data(self, values: dict[str, Any]) -> dict[str, Any]:
         """Add fake user-data when offline-client is used.
 
         Hotfix until WebClient is working.

--- a/shepherd_core/shepherd_core/testbed_client/client_abc_fix.py
+++ b/shepherd_core/shepherd_core/testbed_client/client_abc_fix.py
@@ -53,11 +53,11 @@ class AbcClient(ABC):
         pass
 
     @abstractmethod
-    def try_inheritance(self, model_type: str, values: dict) -> (dict, list):
+    def try_inheritance(self, model_type: str, values: dict) -> tuple[dict, list]:
         # TODO: maybe internal? yes
         pass
 
-    def try_completing_model(self, model_type: str, values: dict) -> (dict, list):
+    def try_completing_model(self, model_type: str, values: dict) -> tuple[dict, list]:
         """Init by name/id, for none existing instances raise Exception.
 
         This is the main entry-point for querying a model (used be the core-lib).
@@ -82,7 +82,7 @@ class FixturesClient(AbcClient):
 
     def __init__(self) -> None:
         super().__init__()
-        self._fixtures: Optional[Fixtures] = Fixtures()
+        self._fixtures: Fixtures = Fixtures()
 
     def insert(self, data: ShpModel) -> bool:
         wrap = Wrapper(
@@ -107,7 +107,7 @@ class FixturesClient(AbcClient):
             return self._fixtures[model_type].query_name(name)
         raise ValueError("Query needs either uid or name of object")
 
-    def try_inheritance(self, model_type: str, values: dict) -> (dict, list):
+    def try_inheritance(self, model_type: str, values: dict) -> tuple[dict, list]:
         return self._fixtures[model_type].inheritance(values)
 
     def fill_in_user_data(self, values: dict) -> dict:

--- a/shepherd_core/shepherd_core/testbed_client/client_abc_fix.py
+++ b/shepherd_core/shepherd_core/testbed_client/client_abc_fix.py
@@ -20,8 +20,9 @@ from abc import abstractmethod
 from typing import Any
 from typing import Optional
 
-from ..data_models.base.shepherd import ShpModel
-from ..data_models.base.wrapper import Wrapper
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.base.wrapper import Wrapper
+
 from .fixtures import Fixtures
 
 

--- a/shepherd_core/shepherd_core/testbed_client/client_abc_fix.py
+++ b/shepherd_core/shepherd_core/testbed_client/client_abc_fix.py
@@ -17,7 +17,6 @@ TODO: Comfort functions missing
 
 from abc import ABC
 from abc import abstractmethod
-from typing import List
 from typing import Optional
 
 from ..data_models.base.shepherd import ShpModel
@@ -40,11 +39,11 @@ class AbcClient(ABC):
         """
 
     @abstractmethod
-    def query_ids(self, model_type: str) -> List[int]:
+    def query_ids(self, model_type: str) -> list[int]:
         pass
 
     @abstractmethod
-    def query_names(self, model_type: str) -> List[str]:
+    def query_names(self, model_type: str) -> list[str]:
         pass
 
     @abstractmethod
@@ -93,10 +92,10 @@ class FixturesClient(AbcClient):
         self._fixtures.insert_model(wrap)
         return True
 
-    def query_ids(self, model_type: str) -> List[int]:
+    def query_ids(self, model_type: str) -> list[int]:
         return list(self._fixtures[model_type].elements_by_id.keys())
 
-    def query_names(self, model_type: str) -> List[str]:
+    def query_names(self, model_type: str) -> list[str]:
         return list(self._fixtures[model_type].elements_by_name.keys())
 
     def query_item(

--- a/shepherd_core/shepherd_core/testbed_client/client_web.py
+++ b/shepherd_core/shepherd_core/testbed_client/client_web.py
@@ -2,7 +2,6 @@
 
 from importlib import import_module
 from pathlib import Path
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -57,10 +56,10 @@ class WebClient(AbcClient):
         r.raise_for_status()
         return True
 
-    def query_ids(self, model_type: str) -> List[int]:
+    def query_ids(self, model_type: str) -> list[int]:
         raise NotImplementedError("TODO")
 
-    def query_names(self, model_type: str) -> List[str]:
+    def query_names(self, model_type: str) -> list[str]:
         raise NotImplementedError("TODO")
 
     def query_item(

--- a/shepherd_core/shepherd_core/testbed_client/client_web.py
+++ b/shepherd_core/shepherd_core/testbed_client/client_web.py
@@ -8,9 +8,10 @@ from typing import Union
 
 from pydantic import validate_call
 
-from ..commons import testbed_server_default
-from ..data_models.base.shepherd import ShpModel
-from ..data_models.base.wrapper import Wrapper
+from shepherd_core.commons import testbed_server_default
+from shepherd_core.data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.base.wrapper import Wrapper
+
 from .client_abc_fix import AbcClient
 from .user_model import User
 

--- a/shepherd_core/shepherd_core/testbed_client/client_web.py
+++ b/shepherd_core/shepherd_core/testbed_client/client_web.py
@@ -8,7 +8,7 @@ from typing import Union
 
 from pydantic import validate_call
 
-from shepherd_core.commons import testbed_server_default
+from shepherd_core.commons import TESTBED_SERVER_URI
 from shepherd_core.data_models.base.shepherd import ShpModel
 from shepherd_core.data_models.base.wrapper import Wrapper
 
@@ -38,7 +38,7 @@ class WebClient(AbcClient):
         if not hasattr(self, "_token"):
             # add default values
             self._token: str = "basic_public_access"  # noqa: S105
-            self._server: str = testbed_server_default
+            self._server: str = TESTBED_SERVER_URI
             self._user: Optional[User] = None
             self._key: Optional[str] = None
             self._connected: bool = False

--- a/shepherd_core/shepherd_core/testbed_client/client_web.py
+++ b/shepherd_core/shepherd_core/testbed_client/client_web.py
@@ -2,6 +2,7 @@
 
 from importlib import import_module
 from pathlib import Path
+from typing import Any
 from typing import Optional
 from typing import Union
 
@@ -69,10 +70,12 @@ class WebClient(AbcClient):
     ) -> dict:
         raise NotImplementedError("TODO")
 
-    def try_inheritance(self, model_type: str, values: dict) -> tuple[dict, list]:
+    def try_inheritance(
+        self, model_type: str, values: dict[str, Any]
+    ) -> tuple[dict[str, Any], list[str]]:
         raise NotImplementedError("TODO")
 
-    def fill_in_user_data(self, values: dict) -> dict:
+    def fill_in_user_data(self, values: dict[str, Any]) -> dict[str, Any]:
         if self._user is None:
             return values
         if values.get("owner") is None:

--- a/shepherd_core/shepherd_core/testbed_client/fixtures.py
+++ b/shepherd_core/shepherd_core/testbed_client/fixtures.py
@@ -14,10 +14,11 @@ import yaml
 from pydantic import validate_call
 from typing_extensions import Self
 
-from ..data_models.base.timezone import local_now
-from ..data_models.base.timezone import local_tz
-from ..data_models.base.wrapper import Wrapper
-from ..logger import logger
+from shepherd_core.data_models.base.timezone import local_now
+from shepherd_core.data_models.base.timezone import local_tz
+from shepherd_core.data_models.base.wrapper import Wrapper
+from shepherd_core.logger import logger
+
 from .cache_path import cache_user_path
 
 # Proposed field-name:

--- a/shepherd_core/shepherd_core/testbed_client/fixtures.py
+++ b/shepherd_core/shepherd_core/testbed_client/fixtures.py
@@ -42,25 +42,26 @@ class Fixture:
     def insert(self, data: Wrapper) -> None:
         # ⤷ TODO: could get easier
         #    - when not model_name but class used
-        #    - use doubleref name->id->data (safes RAM)
+        #    - use doubleref name->id->data (saves RAM)
         if data.datatype.lower() != self.model_type.lower():
             return
         if "name" not in data.parameters:
             return
         name = str(data.parameters["name"]).lower()
         _id = data.parameters["id"]
-        data = data.parameters
-        self.elements_by_name[name] = data
-        self.elements_by_id[_id] = data
+        data_model = data.parameters
+        self.elements_by_name[name] = data_model
+        self.elements_by_id[_id] = data_model
         # update iterator
-        self._iter_list: list = list(self.elements_by_name.values())
+        self._iter_list = list(self.elements_by_name.values())
 
     def __getitem__(self, key: Union[str, int]) -> dict:
         if isinstance(key, str):
             key = key.lower()
             if key in self.elements_by_name:
                 return self.elements_by_name[key]
-            key = int(key) if key.isdigit() else None
+            if key.isdigit():
+                key = int(key)
         if key in self.elements_by_id:
             return self.elements_by_id[int(key)]
         msg = f"{self.model_type} '{key}' not found!"
@@ -84,7 +85,9 @@ class Fixture:
     def refs(self) -> dict:
         return {_i["id"]: _i["name"] for _i in self.elements_by_id.values()}
 
-    def inheritance(self, values: dict, chain: Optional[list] = None) -> (dict, list):
+    def inheritance(
+        self, values: dict[str, Union[str, int]], chain: Optional[list] = None
+    ) -> tuple[dict, list]:
         if chain is None:
             chain = []
         values = copy.copy(values)

--- a/shepherd_core/shepherd_core/testbed_client/fixtures.py
+++ b/shepherd_core/shepherd_core/testbed_client/fixtures.py
@@ -86,8 +86,8 @@ class Fixture:
         return {_i["id"]: _i["name"] for _i in self.elements_by_id.values()}
 
     def inheritance(
-        self, values: dict[str, Union[str, int]], chain: Optional[list] = None
-    ) -> tuple[dict, list]:
+        self, values: dict[str, Any], chain: Optional[list[str]] = None
+    ) -> tuple[dict[str, Any], list[str]]:
         if chain is None:
             chain = []
         values = copy.copy(values)

--- a/shepherd_core/shepherd_core/testbed_client/fixtures.py
+++ b/shepherd_core/shepherd_core/testbed_client/fixtures.py
@@ -2,12 +2,11 @@
 
 import copy
 import pickle
+from collections.abc import Mapping
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
-from typing import Dict
-from typing import Mapping
 from typing import Optional
 from typing import Union
 
@@ -34,8 +33,8 @@ class Fixture:
 
     def __init__(self, model_type: str) -> None:
         self.model_type: str = model_type.lower()
-        self.elements_by_name: Dict[str, dict] = {}
-        self.elements_by_id: Dict[int, dict] = {}
+        self.elements_by_name: dict[str, dict] = {}
+        self.elements_by_id: dict[int, dict] = {}
         # Iterator reset
         self._iter_index: int = 0
         self._iter_list: list = list(self.elements_by_name.values())
@@ -181,7 +180,7 @@ class Fixtures:
             self.file_path = Path(__file__).parent.parent.resolve() / "data_models"
         else:
             self.file_path = file_path
-        self.components: Dict[str, Fixture] = {}
+        self.components: dict[str, Fixture] = {}
         cache_file = cache_user_path / "fixtures.pickle"
         sheep_detect = Path("/lib/firmware/am335x-pru0-fw").exists()
 

--- a/shepherd_core/shepherd_core/testbed_client/user_model.py
+++ b/shepherd_core/shepherd_core/testbed_client/user_model.py
@@ -17,9 +17,9 @@ from pydantic import StringConstraints
 from pydantic import model_validator
 from pydantic import validate_call
 
-from ..data_models.base.content import NameStr
-from ..data_models.base.content import SafeStr
-from ..data_models.base.shepherd import ShpModel
+from shepherd_core.data_models.base.content import NameStr
+from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.shepherd import ShpModel
 
 
 @validate_call

--- a/shepherd_core/shepherd_core/testbed_client/user_model.py
+++ b/shepherd_core/shepherd_core/testbed_client/user_model.py
@@ -3,6 +3,7 @@
 import secrets
 from hashlib import pbkdf2_hmac
 from typing import Annotated
+from typing import Any
 from typing import Optional
 from typing import Union
 from uuid import uuid4
@@ -63,7 +64,7 @@ class User(ShpModel):
 
     @model_validator(mode="before")
     @classmethod
-    def query_database(cls, values: dict) -> dict:
+    def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         # TODO:
 
         # post correction

--- a/shepherd_core/shepherd_core/testbed_client/user_model.py
+++ b/shepherd_core/shepherd_core/testbed_client/user_model.py
@@ -2,6 +2,7 @@
 
 import secrets
 from hashlib import pbkdf2_hmac
+from typing import Annotated
 from typing import Optional
 from typing import Union
 from uuid import uuid4
@@ -14,7 +15,6 @@ from pydantic import SecretStr
 from pydantic import StringConstraints
 from pydantic import model_validator
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 from ..data_models.base.content import NameStr
 from ..data_models.base.content import SafeStr

--- a/shepherd_core/shepherd_core/version.py
+++ b/shepherd_core/shepherd_core/version.py
@@ -1,3 +1,3 @@
 """Separated string avoids circular imports."""
 
-version: str = "2025.04.1"
+version: str = "2025.04.2"

--- a/shepherd_core/shepherd_core/vsource/target_model.py
+++ b/shepherd_core/shepherd_core/vsource/target_model.py
@@ -79,9 +79,9 @@ class DiodeTarget(TargetABC):
 
     def step(self, voltage_uV: int, *, pwr_good: bool) -> float:
         if pwr_good or not self.ctrl:
-            V_CC = voltage_uV * 1e-6
-            V_D = V_CC / 2
-            I_R = I_D = 0
+            V_CC: float = voltage_uV * 1e-6
+            V_D: float = V_CC / 2
+            I_R = I_D = 0.0
             # there is no direct formular, but this iteration converges fast
             for _ in range(10):
                 # low voltages tend to produce log(x<0)=err

--- a/shepherd_core/shepherd_core/vsource/virtual_converter_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_converter_model.py
@@ -17,9 +17,9 @@ Compromises:
 import math
 from typing import Optional
 
-from ..data_models import CalibrationEmulator
-from ..data_models.content.virtual_source import LUT_SIZE
-from ..data_models.content.virtual_source import ConverterPRUConfig
+from shepherd_core.data_models import CalibrationEmulator
+from shepherd_core.data_models.content.virtual_source import LUT_SIZE
+from shepherd_core.data_models.content.virtual_source import ConverterPRUConfig
 
 
 class PruCalibration:

--- a/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
@@ -16,8 +16,8 @@ Compromises:
 
 """
 
-from ..data_models.content.virtual_harvester import HarvesterPRUConfig
-from ..logger import logger
+from shepherd_core.data_models.content.virtual_harvester import HarvesterPRUConfig
+from shepherd_core.logger import logger
 
 
 class VirtualHarvesterModel:

--- a/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_harvester_model.py
@@ -16,8 +16,6 @@ Compromises:
 
 """
 
-from typing import Tuple
-
 from ..data_models.content.virtual_harvester import HarvesterPRUConfig
 from ..logger import logger
 
@@ -94,7 +92,7 @@ class VirtualHarvesterModel:
         self.voltage_nxt: int = 0
         self.current_nxt: int = 0
 
-    def ivcurve_sample(self, _voltage_uV: int, _current_nA: int) -> Tuple[int, int]:
+    def ivcurve_sample(self, _voltage_uV: int, _current_nA: int) -> tuple[int, int]:
         if self._cfg.window_size <= 1:
             return _voltage_uV, _current_nA
         if self._cfg.algorithm >= self.HRV_MPPT_OPT:
@@ -108,7 +106,7 @@ class VirtualHarvesterModel:
         # next line is only implied in C
         return _voltage_uV, _current_nA
 
-    def ivcurve_2_cv(self, _voltage_uV: int, _current_nA: int) -> Tuple[int, int]:
+    def ivcurve_2_cv(self, _voltage_uV: int, _current_nA: int) -> tuple[int, int]:
         compare_now = _voltage_uV < self.voltage_set_uV
         step_size_now = abs(_voltage_uV - self.voltage_last)
         distance_now = abs(_voltage_uV - self.voltage_set_uV)
@@ -146,7 +144,7 @@ class VirtualHarvesterModel:
         self.compare_last = compare_now
         return self.voltage_hold, self.current_hold
 
-    def ivcurve_2_mppt_voc(self, _voltage_uV: int, _current_nA: int) -> Tuple[int, int]:
+    def ivcurve_2_mppt_voc(self, _voltage_uV: int, _current_nA: int) -> tuple[int, int]:
         self.interval_step = self.interval_step + 1
         if self.interval_step >= self._cfg.interval_n:
             self.interval_step = 0
@@ -176,7 +174,7 @@ class VirtualHarvesterModel:
 
         return _voltage_uV, _current_nA
 
-    def ivcurve_2_mppt_po(self, _voltage_uV: int, _current_nA: int) -> Tuple[int, int]:
+    def ivcurve_2_mppt_po(self, _voltage_uV: int, _current_nA: int) -> tuple[int, int]:
         self.interval_step = self.interval_step + 1
         if self.interval_step >= self._cfg.interval_n:
             self.interval_step = 0
@@ -220,7 +218,7 @@ class VirtualHarvesterModel:
 
         return _voltage_uV, _current_nA
 
-    def ivcurve_2_mppt_opt(self, _voltage_uV: int, _current_nA: int) -> Tuple[int, int]:
+    def ivcurve_2_mppt_opt(self, _voltage_uV: int, _current_nA: int) -> tuple[int, int]:
         self.age_now += 1
         self.age_nxt += 1
 

--- a/shepherd_core/shepherd_core/vsource/virtual_harvester_simulation.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_harvester_simulation.py
@@ -13,11 +13,12 @@ from typing import Optional
 
 from tqdm import tqdm
 
-from .. import CalibrationHarvester
-from .. import Reader
-from .. import Writer
-from ..data_models.content.virtual_harvester import HarvesterPRUConfig
-from ..data_models.content.virtual_harvester import VirtualHarvesterConfig
+from shepherd_core.data_models.base.calibration import CalibrationHarvester
+from shepherd_core.data_models.content.virtual_harvester import HarvesterPRUConfig
+from shepherd_core.data_models.content.virtual_harvester import VirtualHarvesterConfig
+from shepherd_core.reader import Reader
+from shepherd_core.writer import Writer
+
 from .virtual_harvester_model import VirtualHarvesterModel
 
 

--- a/shepherd_core/shepherd_core/vsource/virtual_source_model.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_source_model.py
@@ -12,11 +12,12 @@ NOTE: DO NOT OPTIMIZE -> stay close to original code-base
 
 from typing import Optional
 
-from ..data_models import CalibrationEmulator
-from ..data_models import EnergyDType
-from ..data_models import VirtualSourceConfig
-from ..data_models.content.virtual_harvester import HarvesterPRUConfig
-from ..data_models.content.virtual_source import ConverterPRUConfig
+from shepherd_core.data_models.base.calibration import CalibrationEmulator
+from shepherd_core.data_models.content.energy_environment import EnergyDType
+from shepherd_core.data_models.content.virtual_harvester import HarvesterPRUConfig
+from shepherd_core.data_models.content.virtual_source import ConverterPRUConfig
+from shepherd_core.data_models.content.virtual_source import VirtualSourceConfig
+
 from .virtual_converter_model import PruCalibration
 from .virtual_converter_model import VirtualConverterModel
 from .virtual_harvester_model import VirtualHarvesterModel

--- a/shepherd_core/shepherd_core/vsource/virtual_source_simulation.py
+++ b/shepherd_core/shepherd_core/vsource/virtual_source_simulation.py
@@ -14,13 +14,14 @@ from typing import Optional
 import numpy as np
 from tqdm import tqdm
 
-from .. import CalibrationEmulator
-from .. import Reader
-from .. import Writer
-from ..data_models import VirtualSourceConfig
-from ..logger import logger
-from . import VirtualSourceModel
+from shepherd_core.data_models.base.calibration import CalibrationEmulator
+from shepherd_core.data_models.content.virtual_source import VirtualSourceConfig
+from shepherd_core.logger import logger
+from shepherd_core.reader import Reader
+from shepherd_core.writer import Writer
+
 from .target_model import TargetABC
+from .virtual_source_model import VirtualSourceModel
 
 
 def simulate_source(

--- a/shepherd_core/shepherd_core/writer.py
+++ b/shepherd_core/shepherd_core/writer.py
@@ -3,14 +3,13 @@
 import logging
 import math
 import pathlib
+from collections.abc import Mapping
 from datetime import timedelta
 from itertools import product
 from pathlib import Path
 from types import TracebackType
 from typing import Any
-from typing import Mapping
 from typing import Optional
-from typing import Type
 from typing import Union
 
 import h5py
@@ -212,7 +211,7 @@ class Writer(Reader):
 
     def __exit__(
         self,
-        typ: Optional[Type[BaseException]] = None,
+        typ: Optional[type[BaseException]] = None,
         exc: Optional[BaseException] = None,
         tb: Optional[TracebackType] = None,
         extra_arg: int = 0,

--- a/shepherd_core/shepherd_core/writer.py
+++ b/shepherd_core/shepherd_core/writer.py
@@ -17,9 +17,8 @@ import numpy as np
 import yaml
 from pydantic import validate_call
 from typing_extensions import Self
-from yaml import Dumper
+from yaml import Node
 from yaml import SafeDumper
-from yaml import ScalarNode
 
 from .commons import samplerate_sps_default
 from .data_models.base.calibration import CalibrationEmulator as CalEmu
@@ -33,13 +32,13 @@ from .reader import Reader
 
 # copy of core/models/base/shepherd - needed also here
 def path2str(
-    dumper: Dumper, data: Union[pathlib.Path, pathlib.WindowsPath, pathlib.PosixPath]
-) -> ScalarNode:
+    dumper: SafeDumper, data: Union[pathlib.Path, pathlib.WindowsPath, pathlib.PosixPath]
+) -> Node:
     """Add a yaml-representation for a specific datatype."""
     return dumper.represent_scalar("tag:yaml.org,2002:str", str(data.as_posix()))
 
 
-def time2int(dumper: Dumper, data: timedelta) -> ScalarNode:
+def time2int(dumper: SafeDumper, data: timedelta) -> Node:
     """Add a yaml-representation for a specific datatype."""
     return dumper.represent_scalar("tag:yaml.org,2002:int", str(int(data.total_seconds())))
 

--- a/shepherd_core/tests/conftest.py
+++ b/shepherd_core/tests/conftest.py
@@ -1,6 +1,6 @@
 import subprocess
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable  # py38, later use: from collections.abc import Iterable
 
 import numpy as np
 import pytest

--- a/shepherd_core/tests/test_reader.py
+++ b/shepherd_core/tests/test_reader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import h5py
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from shepherd_core import Reader
 from shepherd_core import Writer
@@ -33,7 +34,7 @@ def test_reader_items(data_h5: Path) -> None:
 
 
 def test_reader_open(tmp_path: Path) -> None:
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         Reader(file_path=None)
 
     tmp_file = (tmp_path / "data.h5").resolve()

--- a/shepherd_core/tests/test_reader.py
+++ b/shepherd_core/tests/test_reader.py
@@ -190,7 +190,7 @@ def test_reader_fault_non_eq_time(data_h5: Path) -> None:
 
 def test_reader_fault_unaligned(data_h5: Path) -> None:
     with Writer(data_h5, modify_existing=True) as sfw:
-        new_size = sfw.samples_per_buffer / 2
+        new_size = sfw.BUFFER_SAMPLES_N / 2
         sfw.h5file["data"]["time"].resize((new_size,))
         sfw.h5file["data"]["voltage"].resize((new_size,))
         sfw.h5file["data"]["current"].resize((new_size,))
@@ -252,7 +252,7 @@ def test_reader_fault_jumps_timestamp(data_h5: Path) -> None:
     with Reader(data_h5, verbose=True) as sfr:
         assert sfr.check_timediffs()
     with Writer(data_h5, modify_existing=True) as sfw:
-        sfw.h5file["data"]["time"][sfw.samples_per_buffer] = 0
+        sfw.h5file["data"]["time"][sfw.BUFFER_SAMPLES_N] = 0
     with Reader(data_h5, verbose=True) as sfr:
         assert not sfr.check_timediffs()
 

--- a/shepherd_core/tests/test_writer.py
+++ b/shepherd_core/tests/test_writer.py
@@ -137,7 +137,7 @@ def test_writer_faulty_window(h5_path: Path) -> None:
 
 def test_writer_append_raw(h5_path: Path) -> None:
     with Writer(h5_path) as sfw:
-        data_nd = np.zeros((sfw.samples_per_buffer,))
+        data_nd = np.zeros((sfw.BUFFER_SAMPLES_N,))
         time_float = 5.5
         time_int = 3
         time_nd = 3 + data_nd
@@ -150,7 +150,7 @@ def test_writer_append_raw(h5_path: Path) -> None:
 
 def test_writer_align(h5_path: Path) -> None:
     with Writer(h5_path) as sfw:
-        length = int(5.5 * sfw.samples_per_buffer)
+        length = int(5.5 * sfw.BUFFER_SAMPLES_N)
         time_nd = np.arange(0, length * sfw.sample_interval_ns, sfw.sample_interval_ns)
         data_nd = np.zeros((int(length),))
         sfw.append_iv_data_raw(time_nd, data_nd, data_nd)
@@ -160,7 +160,7 @@ def test_writer_align(h5_path: Path) -> None:
 
 def test_writer_not_align(h5_path: Path) -> None:
     with Writer(h5_path) as sfw:
-        length = int(5.5 * sfw.samples_per_buffer)
+        length = int(5.5 * sfw.BUFFER_SAMPLES_N)
         sample_interval = 10 * sfw.sample_interval_ns
         time_nd = np.arange(0, length * sample_interval, sample_interval)
         data_nd = np.zeros((int(length),))

--- a/shepherd_data/examples/repair_recordings.py
+++ b/shepherd_data/examples/repair_recordings.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
                 fh = shp.Reader(file, verbose=False)  # reopen file
 
         # unaligned datasets
-        remaining_size = fh.h5file["data"]["voltage"].shape[0] % shp.Reader.samples_per_buffer
+        remaining_size = fh.h5file["data"]["voltage"].shape[0] % shp.Reader.BUFFER_SAMPLES_N
         if remaining_size != 0:
             print(" -> will align datasets")
             fh.__exit__()
@@ -56,8 +56,8 @@ if __name__ == "__main__":
 
         # invalid modes
         mode = fh.get_mode()
-        if mode not in shp.Reader.mode_dtype_dict:
-            mode = shp.Writer.mode_default
+        if mode not in shp.Reader.MODE_TO_DTYPE:
+            mode = shp.Writer.MODE_DEFAULT
             if "har" in fh.get_mode():  # can be harvest, harvesting, ...
                 mode = "harvester"
             elif "emu" in fh.get_mode():  # can be emulation, emulate
@@ -70,8 +70,8 @@ if __name__ == "__main__":
 
         # invalid datatype
         datatype = fh.get_datatype()
-        if datatype not in shp.Reader.mode_dtype_dict[mode]:
-            datatype = shp.Writer.datatype_default
+        if datatype not in shp.Reader.MODE_TO_DTYPE[mode]:
+            datatype = shp.Writer.DATATYPE_DEFAULT
             if "curv" in str(fh.get_datatype()):
                 datatype = EnergyDType.ivcurve
             print(f" -> will set datatype = {datatype}")

--- a/shepherd_data/pyproject.toml
+++ b/shepherd_data/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pandas>=2.0.0",  # full-version, v2 is OK
     "pyYAML",
     "scipy",   # full-version
-    "shepherd-core[inventory]>=2025.04.1",  # libs are strongly coupled
+    "shepherd-core[inventory]>=2025.04.2",  # libs are strongly coupled
     "tqdm",    # full-version
 ]
 

--- a/shepherd_data/pyproject.toml
+++ b/shepherd_data/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -29,7 +28,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "click",
     "h5py",
@@ -101,6 +100,6 @@ addopts = "-vvv --stepwise" # opts: verbose result for each tests
 source = ["shepherd_data"]
 
 [tool.mypy]
-python_version = 3.8
+python_version = 3.9
 ignore_missing_imports = true
 disable_error_code = ["call-arg", ]

--- a/shepherd_data/pyproject.toml
+++ b/shepherd_data/pyproject.toml
@@ -103,3 +103,7 @@ source = ["shepherd_data"]
 python_version = 3.9
 ignore_missing_imports = true
 disable_error_code = ["call-arg", ]
+exclude = [
+    "build/",
+    ".egg-info/",
+]

--- a/shepherd_data/shepherd_data/__init__.py
+++ b/shepherd_data/shepherd_data/__init__.py
@@ -11,7 +11,7 @@ from shepherd_core import Writer
 
 from .reader import Reader
 
-__version__ = "2025.04.1"
+__version__ = "2025.04.2"
 
 __all__ = [
     "Reader",

--- a/shepherd_data/shepherd_data/cli.py
+++ b/shepherd_data/shepherd_data/cli.py
@@ -5,7 +5,6 @@ import sys
 from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
-from typing import List
 from typing import Optional
 
 import click
@@ -21,7 +20,7 @@ from .reader import Reader
 logger = logging.getLogger("SHPData.cli")
 
 
-def path_to_flist(data_path: Path, *, recurse: bool = False) -> List[Path]:
+def path_to_flist(data_path: Path, *, recurse: bool = False) -> list[Path]:
     """Every path gets transformed to a list of paths.
 
     Transformations:

--- a/shepherd_data/shepherd_data/ivonne.py
+++ b/shepherd_data/shepherd_data/ivonne.py
@@ -17,7 +17,6 @@ import pickle
 from pathlib import Path
 from types import TracebackType
 from typing import Optional
-from typing import Type
 
 import numpy as np
 import pandas as pd
@@ -88,7 +87,7 @@ class Reader:
 
     def __exit__(
         self,
-        typ: Optional[Type[BaseException]] = None,
+        typ: Optional[type[BaseException]] = None,
         exc: Optional[BaseException] = None,
         tb: Optional[TracebackType] = None,
         extra_arg: int = 0,

--- a/shepherd_data/shepherd_data/ivonne.py
+++ b/shepherd_data/shepherd_data/ivonne.py
@@ -23,7 +23,8 @@ import pandas as pd
 from tqdm import trange
 from typing_extensions import Self
 
-from . import Writer
+from shepherd_core.writer import Writer as CoreWriter
+
 from .mppt import MPPTracker
 from .mppt import OptimalTracker
 from .mppt import iv_model
@@ -131,7 +132,7 @@ class Reader:
 
         v_proto = np.linspace(0, v_max, pts_per_curve)
 
-        with Writer(shp_output, datatype="ivcurve", window_samples=pts_per_curve) as sfw:
+        with CoreWriter(shp_output, datatype="ivcurve", window_samples=pts_per_curve) as sfw:
             sfw.store_hostname("IVonne")
             curve_interval_us = round(sfw.sample_interval_ns * pts_per_curve / 1000)
             up_factor = self.sample_interval_ns // sfw.sample_interval_ns
@@ -206,7 +207,7 @@ class Reader:
                 v_max,
             )
 
-        with Writer(shp_output, datatype="ivsample") as sfw:
+        with CoreWriter(shp_output, datatype="ivsample") as sfw:
             sfw.store_hostname("IVonne")
             interval_us = round(sfw.sample_interval_ns / 1000)
             up_factor = self.sample_interval_ns // sfw.sample_interval_ns
@@ -259,7 +260,7 @@ class Reader:
             self._logger.info("File already exists, will skip '%s'", shp_output.name)
             return
 
-        with Writer(shp_output, datatype="isc_voc") as sfw:
+        with CoreWriter(shp_output, datatype="isc_voc") as sfw:
             sfw.store_hostname("IVonne")
             interval_us = round(sfw.sample_interval_ns / 1000)
             up_factor = self.sample_interval_ns // sfw.sample_interval_ns

--- a/shepherd_data/shepherd_data/reader.py
+++ b/shepherd_data/shepherd_data/reader.py
@@ -34,9 +34,9 @@ class Reader(CoreReader):
 
     def __init__(
         self,
-        file_path: Optional[Path],
+        file_path: Path,
         *,
-        verbose: Optional[bool] = True,
+        verbose: bool = True,
     ) -> None:
         super().__init__(file_path, verbose=verbose)
 

--- a/shepherd_data/shepherd_data/reader.py
+++ b/shepherd_data/shepherd_data/reader.py
@@ -1,13 +1,11 @@
 """Reader-Baseclass for opening shepherds hdf5-files."""
 
 import math
+from collections.abc import Mapping
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Dict
-from typing import List
-from typing import Mapping
 from typing import Optional
-from typing import Sequence
 from typing import Union
 
 import h5py
@@ -59,13 +57,13 @@ class Reader(CoreReader):
         if csv_path.exists():
             self._logger.info("File already exists, will skip '%s'", csv_path.name)
             return 0
-        datasets: List[str] = [
+        datasets: list[str] = [
             str(key) for key in h5_group if isinstance(h5_group[key], h5py.Dataset)
         ]
         datasets.remove("time")
         datasets = ["time", *datasets]
         separator = separator.strip().ljust(2)
-        header_elements: List[str] = [
+        header_elements: list[str] = [
             str(h5_group[key].attrs["description"]).replace(", ", separator) for key in datasets
         ]
         header: str = separator.join(header_elements)
@@ -74,10 +72,10 @@ class Reader(CoreReader):
             csv_file.write(header + "\n")
             ts_gain = h5_group["time"].attrs.get("gain", 1e-9)
             # for converting data to si - if raw=false
-            gains: Dict[str, float] = {
+            gains: dict[str, float] = {
                 key: h5_group[key].attrs.get("gain", 1.0) for key in datasets[1:]
             }
-            offsets: Dict[str, float] = {
+            offsets: dict[str, float] = {
                 key: h5_group[key].attrs.get("offset", 1.0) for key in datasets[1:]
             }
             for idx, time_ns in enumerate(h5_group["time"][:]):
@@ -460,7 +458,7 @@ class Reader(CoreReader):
         end_s: Optional[float] = None,
         *,
         relative_timestamp: bool = True,
-    ) -> Optional[Dict]:
+    ) -> Optional[dict]:
         """Provide down-sampled iv-data that can be fed into plot_to_file().
 
         :param start_s: time in seconds, relative to start of recording


### PR DESCRIPTION
- drop python 3.8 support
- supported python is now 3.9 - 3.13
- heavy changes in typesystem - mypy was used to find possible bugs (NOTE: still work in progress)
- user facing interfaces should be safer to use
- pathlib now has .with_stem() to simplify code
- rename constants to upper-case
  - 1-to-1: samplerate_sps_default,
  - core.Reader().mode_dtype_dict -> .MODE_TO_DTYPE
  - core.Reader().samples_per_buffer -> .BUFFER_SAMPLES_N
- replace relative imports from parent with absolute ones