### PR TITLE
Dev

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2025.05.2
+current_version = 2025.05.3
 commit = False
 tag = False
 

--- a/.github/workflows/publish_core.yaml
+++ b/.github/workflows/publish_core.yaml
@@ -1,6 +1,7 @@
 name: Publish Core-Package to PyPi
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
   push:

--- a/.github/workflows/publish_data.yaml
+++ b/.github/workflows/publish_data.yaml
@@ -1,6 +1,7 @@
 name: Publish Data-Package to PyPi
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
   push:

--- a/.github/workflows/publish_data.yaml
+++ b/.github/workflows/publish_data.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
 
-  publish-core:
+  publish-data:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/quality_assurance.yaml
+++ b/.github/workflows/quality_assurance.yaml
@@ -1,4 +1,4 @@
-name: Quality Control
+name: QA-Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
   test-python:
     uses: ./.github/workflows/py_tests.yaml
 
-  quality-control:
+  quality-assurance:
     runs-on: ubuntu-latest
     needs:
       - static-analysis

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,13 +11,13 @@ permissions:
   contents: write
 
 jobs:
-  run-quality-control:
+  run-quality-assurance:
     uses: ./.github/workflows/quality_assurance.yaml
   release:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
-      - run-quality-control
+      - run-quality-assurance
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -1,4 +1,4 @@
-name: Static analysis / pre-commit
+name: Static analysis
 
 on:
   workflow_call:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,10 +51,10 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.11.9'
+    rev: 'v0.11.10'
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
         args: ["--fix", "--exit-non-zero-on-fix"]
 
   - repo: https://github.com/codespell-project/codespell
@@ -64,7 +64,7 @@ repos:
         additional_dependencies: ["tomli"]  # for py<3.11
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013"] # ignore line length

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## v2025.05.3
 
-- fix naming of `UartTracer` in favor of `UartLogger` (**breaking change, required for sheep v0.9.0**)
+- fix naming of `UartTracer` in favor of separate `UartLogger` (**breaking change, required for sheep v0.9.0**)
+- `UartLogger` allows setting baudrate, parity, stopbits, bytesize
+- `GPIOTracer` can now be used to mask off unwanted pins
+  - `.gpio` receives a list of int that corresponds with GPIO-number of TargetPort (new 2025 edge connector)
 - change ID generation for compat with WebAPI
 - allow publishing to PyPI by dispatch
-- add separate mock testbed into fixtures
+- add separate mock testbed into fixtures (will be replaced soon, by testbed-client)
 - deprecate `.abort_on_error`
 - detailed doc for harvester config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # History of Changes
 
+## v2025.05.3
+
+- fix naming of `UartTracer` in favor of `UartLogger` (**breaking change, required for sheep v0.9.0**)
+- change ID generation for compat with WebAPI
+- allow publishing to PyPI by dispatch
+- add separate mock testbed into fixtures
+- deprecate `.abort_on_error`
+- detailed doc for harvester config
+
 ## v2025.05.2
 
 - GitHub-workflows
@@ -10,7 +19,7 @@
 
 ## v2025.05.1
 
-- add separate `UartTracer` with new config options (**breaking change, required for sheep v0.9.0**) instead of misusing GPIOTracer
+- add separate ~~`UartTracer`~~ `UartLogger` with new config options (**breaking change, required for sheep v0.9.0**) instead of misusing GPIOTracer
 - usage of not (yet) implemented features in an `Experiment()` now raises an exception
 - establish consistent naming scheme
   - `IVTrace` for a stream of `IVSample`s and `IVSurface` for a stream of `IVCurve`s

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ coverage report
 ```shell
 pipenv shell
 
-bump2version --allow-dirty --new-version 2025.05.2 patch
+bump2version --allow-dirty --new-version 2025.05.3 patch
 # ⤷ format: year.month.patch_release
 
 pre-commit run --all-files

--- a/extra/gen_rf_survey.py
+++ b/extra/gen_rf_survey.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
                 ),
                 firmware2=sm.Firmware(name="msp430_deep_sleep"),
                 power_tracing=None,
-                uart_tracing=sm.UartTracing(baudrate=115_200),
+                uart_logging=sm.UartLogging(baudrate=115_200),
             )
         ],
     )

--- a/extra/gen_target_tests_testbed.py
+++ b/extra/gen_target_tests_testbed.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
                     firmware2=sm.Firmware(name=fw_msp),
                     power_tracing=sm.PowerTracing(),
                     gpio_tracing=sm.GpioTracing(),
-                    uart_tracing=sm.UartTracing(baudrate=115_200),
+                    uart_logging=sm.UartLogging(baudrate=115_200),
                 )
             ],
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ exclude = [
     "build/",
     ".egg-info/",
 ]
+
+[tool.ty.terminal]
+output-format = "concise"

--- a/shepherd_core/examples/experiment_generic_var1.py
+++ b/shepherd_core/examples/experiment_generic_var1.py
@@ -48,7 +48,7 @@ xp = sm.Experiment(
             ),
             power_tracing=None,
             gpio_tracing=sm.GpioTracing(),
-            uart_tracing=sm.UartTracing(baudrate=115_200),
+            uart_logging=sm.UartLogging(baudrate=115_200),
         ),
     ],
 )

--- a/shepherd_core/shepherd_core/data_models/__init__.py
+++ b/shepherd_core/shepherd_core/data_models/__init__.py
@@ -31,7 +31,7 @@ from .experiment.observer_features import GpioLevel
 from .experiment.observer_features import GpioTracing
 from .experiment.observer_features import PowerTracing
 from .experiment.observer_features import SystemLogging
-from .experiment.observer_features import UartTracing
+from .experiment.observer_features import UartLogging
 from .experiment.target_config import TargetConfig
 
 __all__ = [
@@ -55,7 +55,7 @@ __all__ = [
     "ShpModel",
     "SystemLogging",
     "TargetConfig",
-    "UartTracing",
+    "UartLogging",
     "VirtualHarvesterConfig",
     "VirtualSourceConfig",
     "Wrapper",

--- a/shepherd_core/shepherd_core/data_models/content/_external_fixtures.yaml
+++ b/shepherd_core/shepherd_core/data_models/content/_external_fixtures.yaml
@@ -1,7 +1,7 @@
 - datatype: EnergyEnvironment
   created: 2025-05-12 17:28:39.756999+02:00
   parameters:
-    id: 2639560972524229652
+    id: 263956097252422
     name: eenv_static_2000mV_10mA_3600s
     description: Artificial static Energy Environment, 2000mV, 10mA, 3600s
     comment: null
@@ -24,7 +24,7 @@
 - datatype: EnergyEnvironment
   created: 2025-05-12 17:28:39.764595+02:00
   parameters:
-    id: 9823394105967169626
+    id: 98233941059
     name: eenv_static_2000mV_1mA_3600s
     description: Artificial static Energy Environment, 2000mV, 1mA, 3600s
     comment: null
@@ -47,7 +47,7 @@
 - datatype: EnergyEnvironment
   created: 2025-05-12 17:28:39.772144+02:00
   parameters:
-    id: 3900615675169501222
+    id: 39006156751
     name: eenv_static_2000mV_50mA_3600s
     description: Artificial static Energy Environment, 2000mV, 50mA, 3600s
     comment: null
@@ -70,7 +70,7 @@
 - datatype: EnergyEnvironment
   created: 2025-05-12 17:28:39.779737+02:00
   parameters:
-    id: 14796673729431137386
+    id: 1479667372943113
     name: eenv_static_2000mV_5mA_3600s
     description: Artificial static Energy Environment, 2000mV, 5mA, 3600s
     comment: null
@@ -93,7 +93,7 @@
 - datatype: EnergyEnvironment
   created: 2025-05-12 17:28:39.787329+02:00
   parameters:
-    id: 6648482606607441403
+    id: 664848260660744
     name: eenv_static_3000mV_10mA_3600s
     description: Artificial static Energy Environment, 3000mV, 10mA, 3600s
     comment: null
@@ -116,7 +116,7 @@
 - datatype: EnergyEnvironment
   created: 2025-05-12 17:28:39.794922+02:00
   parameters:
-    id: 13566000951043177991
+    id: 1356600095104317
     name: eenv_static_3000mV_1mA_3600s
     description: Artificial static Energy Environment, 3000mV, 1mA, 3600s
     comment: null
@@ -139,7 +139,7 @@
 - datatype: EnergyEnvironment
   created: 2025-05-12 17:28:39.802410+02:00
   parameters:
-    id: 7977778327156610158
+    id: 797777832715661
     name: eenv_static_3000mV_50mA_3600s
     description: Artificial static Energy Environment, 3000mV, 50mA, 3600s
     comment: null
@@ -162,7 +162,7 @@
 - datatype: EnergyEnvironment
   created: 2025-05-12 17:28:39.810147+02:00
   parameters:
-    id: 4900162978999238419
+    id: 490016297899923
     name: eenv_static_3000mV_5mA_3600s
     description: Artificial static Energy Environment, 3000mV, 5mA, 3600s
     comment: null
@@ -269,7 +269,7 @@
 - datatype: Firmware
   created: 2025-05-12 17:28:39.851412+02:00
   parameters:
-    id: 7163917825449888392
+    id: 716391782544988
     name: nrf52_deep_sleep
     description: practically turned off MCU with the lowest possible consumption
     comment: null
@@ -325,7 +325,7 @@
 - datatype: Firmware
   created: 2025-05-12 17:28:39.868340+02:00
   parameters:
-    id: 3174430733058172825
+    id: 317443073305817
     name: nrf52_rf_survey
     description: Link Matrix Generator - TX-Unit - sends packet with every possible
       P_TX, loops until stopped
@@ -354,7 +354,7 @@
 - datatype: Firmware
   created: 2025-05-12 17:28:39.876819+02:00
   parameters:
-    id: 16381936580724580968
+    id: 1638193658072458
     name: nrf52_rf_test
     description: sends out 1 BLE-Packet per second (verify with an app like 'RaMBLE')
     comment: null

--- a/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_harvester.py
@@ -60,7 +60,7 @@ class VirtualHarvesterConfig(ContentModel, title="Config for the Harvester"):
     setpoint_n: Annotated[float, Field(ge=0, le=1.0)] = 0.70
     # ⤷ ie. for mppt_voc
     interval_ms: Annotated[float, Field(ge=0.01, le=1_000_000)] = 100
-    # ⤷ between start of measurements (ie. V_OC)
+    # ⤷ between start of measurements (ie. V_OC) or steps in mppt-po
     duration_ms: Annotated[float, Field(ge=0.01, le=1_000_000)] = 0.1
     # ⤷ of (open voltage) measurement
     rising: bool = True

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source.py
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source.py
@@ -70,6 +70,7 @@ class VirtualSourceConfig(ContentModel, title="Config for the virtual Source"):
     # ⤷ target gets disconnected
     interval_check_thresholds_ms: Annotated[float, Field(ge=0, le=4.29e3)] = 0
     # ⤷ some ICs (BQ) check every 64 ms if output should be disconnected
+    # TODO: add intervals for input-disable, output-disable & power-good-signal
 
     # pwr-good: target is informed on output-pin (hysteresis) -> for intermediate voltage
     V_pwr_good_enable_threshold_mV: Annotated[float, Field(ge=0, le=10_000)] = 2_800

--- a/shepherd_core/shepherd_core/data_models/experiment/experiment.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/experiment.py
@@ -60,9 +60,10 @@ class Experiment(ShpModel, title="Config of an Experiment"):
     @model_validator(mode="after")
     def post_validation(self) -> Self:
         # TODO: only do deep validation with active connection to TB-client
-        # testbed = Testbed()  # this will query the first (and only) entry of client
+        #       or with cached fixtures
+        testbed = Testbed()  # this will query the first (and only) entry of client
         self._validate_targets(self.target_configs)
-        # self._validate_observers(self.target_configs, testbed)
+        self._validate_observers(self.target_configs, testbed)
         if self.duration and self.duration.total_seconds() < 0:
             raise ValueError("Duration of experiment can't be negative.")
         return self

--- a/shepherd_core/shepherd_core/data_models/experiment/experiment.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/experiment.py
@@ -9,6 +9,7 @@ from typing import Optional
 from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
+from typing_extensions import deprecated
 
 from shepherd_core.data_models.base.content import IdInt
 from shepherd_core.data_models.base.content import NameStr
@@ -48,7 +49,7 @@ class Experiment(ShpModel, title="Config of an Experiment"):
     # schedule
     time_start: Optional[datetime] = None  # = ASAP
     duration: Optional[timedelta] = None  # = till EOF
-    abort_on_error: bool = False
+    abort_on_error: Annotated[bool, deprecated("has no effect")] = False
 
     # targets
     target_configs: Annotated[list[TargetConfig], Field(min_length=1, max_length=128)]

--- a/shepherd_core/shepherd_core/data_models/experiment/experiment.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/experiment.py
@@ -58,9 +58,10 @@ class Experiment(ShpModel, title="Config of an Experiment"):
 
     @model_validator(mode="after")
     def post_validation(self) -> Self:
-        testbed = Testbed()  # this will query the first (and only) entry of client
+        # TODO: only do deep validation with active connection to TB-client
+        # testbed = Testbed()  # this will query the first (and only) entry of client
         self._validate_targets(self.target_configs)
-        self._validate_observers(self.target_configs, testbed)
+        # self._validate_observers(self.target_configs, testbed)
         if self.duration and self.duration.total_seconds() < 0:
             raise ValueError("Duration of experiment can't be negative.")
         return self

--- a/shepherd_core/shepherd_core/data_models/experiment/experiment.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/experiment.py
@@ -5,10 +5,7 @@ from datetime import datetime
 from datetime import timedelta
 from typing import Annotated
 from typing import Optional
-from typing import Union
-from uuid import uuid4
 
-from pydantic import UUID4
 from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
@@ -16,6 +13,7 @@ from typing_extensions import Self
 from shepherd_core.data_models.base.content import IdInt
 from shepherd_core.data_models.base.content import NameStr
 from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.content import id_default
 from shepherd_core.data_models.base.shepherd import ShpModel
 from shepherd_core.data_models.testbed.target import Target
 from shepherd_core.data_models.testbed.testbed import Testbed
@@ -29,8 +27,7 @@ class Experiment(ShpModel, title="Config of an Experiment"):
     """Config for experiments on the testbed emulating energy environments for target nodes."""
 
     # General Properties
-    # id: UUID4 ... # TODO: db-migration - temp fix for documentation
-    id: Union[UUID4, int] = Field(default_factory=uuid4)
+    id: int = Field(description="Unique ID", default_factory=id_default)
     # ⤷ TODO: automatic ID is problematic for identification by hash
 
     name: NameStr

--- a/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
@@ -105,7 +105,7 @@ STOPBITS_ONE, STOPBITS_ONE_POINT_FIVE, STOPBITS_TWO = (1, 1.5, 2)
 STOPBITS = (STOPBITS_ONE, STOPBITS_ONE_POINT_FIVE, STOPBITS_TWO)
 
 
-class UartTracing(ShpModel, title="Config for UART Tracing"):
+class UartLogging(ShpModel, title="Config for UART Logging"):
     """Configuration for recording UART-Output of the Target Nodes.
 
     Note that the Communication has to be on a specific port that
@@ -169,9 +169,9 @@ class GpioTracing(ShpModel, title="Config for GPIO-Tracing"):
         if self.gpios is not None:
             raise NotImplementedError("Feature GpioTracing.gpios reserved for future use.")
         if self.uart_decode:
-            raise NotImplementedError(
+            logger.error(
                 "Feature GpioTracing.uart_decode reserved for future use. "
-                "Use UartTracing or manually decode serial with the provided waveform decoder."
+                "Use UartLogging or manually decode serial with the provided waveform decoder."
             )
         return self
 

--- a/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
@@ -148,13 +148,18 @@ class GpioTracing(ShpModel, title="Config for GPIO-Tracing"):
     gpios: GpioList = all_gpio
     """List of GPIO to record.
 
-    Numbering is based on the Target-Port and its GPIO.
-    To make the Port future-safer it offers 16x GPIO and 2x PwrGood.
+    This feature allows to remove unwanted pins from recording,
+    i.e. for chatty pins with separate UART Logging enabled.
+    Numbering is based on the Target-Port and its 16x GPIO and two PwrGood-Signals.
     See doc for nRF_FRAM_Target_v1.3+ to see mapping of target port.
+
+    Example for skipping UART (pin 0 & 1):
+    .gpio = range(2,18)
 
     Note:
     - Cape 2.4 (2023) and lower only has 9x GPIO + 1x PwrGood
-    - Cape 2.5 (2025) has 12x GPIO & both PwrGood
+    - Cape 2.5 (2025) has first 12 GPIO & both PwrGood
+    - this will be mapped accordingly by the observer
     """
 
     # time

--- a/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/observer_features.py
@@ -12,6 +12,7 @@ from pydantic import model_validator
 from typing_extensions import Self
 from typing_extensions import deprecated
 
+from shepherd_core import logger
 from shepherd_core.data_models.base.shepherd import ShpModel
 from shepherd_core.data_models.testbed.gpio import GPIO
 

--- a/shepherd_core/shepherd_core/data_models/experiment/target_config.py
+++ b/shepherd_core/shepherd_core/data_models/experiment/target_config.py
@@ -18,7 +18,7 @@ from shepherd_core.data_models.testbed.target import Target
 from .observer_features import GpioActuation
 from .observer_features import GpioTracing
 from .observer_features import PowerTracing
-from .observer_features import UartTracing
+from .observer_features import UartLogging
 
 
 class TargetConfig(ShpModel, title="Target Config"):
@@ -43,8 +43,8 @@ class TargetConfig(ShpModel, title="Target Config"):
 
     power_tracing: Optional[PowerTracing] = None
     gpio_tracing: Optional[GpioTracing] = None
-    uart_tracing: Optional[UartTracing] = None
     gpio_actuation: Optional[GpioActuation] = None
+    uart_logging: Optional[UartLogging] = None
 
     @model_validator(mode="after")
     def post_validation(self) -> Self:

--- a/shepherd_core/shepherd_core/data_models/task/emulation.py
+++ b/shepherd_core/shepherd_core/data_models/task/emulation.py
@@ -13,6 +13,7 @@ from pydantic import Field
 from pydantic import model_validator
 from pydantic import validate_call
 from typing_extensions import Self
+from typing_extensions import deprecated
 
 from shepherd_core.data_models.base.content import IdInt
 from shepherd_core.data_models.base.shepherd import ShpModel
@@ -63,7 +64,7 @@ class EmulationTask(ShpModel):
     # timestamp or unix epoch time, None = ASAP
     duration: Optional[timedelta] = None
     # ⤷ Duration of recording in seconds, None = till EOF
-    abort_on_error: bool = False  # TODO: remove, should not exist
+    abort_on_error: Annotated[bool, deprecated("has no effect")] = False
 
     # emulation-specific
     use_cal_default: bool = False

--- a/shepherd_core/shepherd_core/data_models/task/emulation.py
+++ b/shepherd_core/shepherd_core/data_models/task/emulation.py
@@ -156,7 +156,6 @@ class EmulationTask(ShpModel):
             output_path=root_path / f"emu_{obs.name}.h5",
             time_start=copy.copy(xp.time_start),
             duration=xp.duration,
-            abort_on_error=xp.abort_on_error,
             enable_io=io_requested,
             io_port=obs.get_target_port(tgt_id),
             pwr_port=obs.get_target_port(tgt_id),

--- a/shepherd_core/shepherd_core/data_models/task/emulation.py
+++ b/shepherd_core/shepherd_core/data_models/task/emulation.py
@@ -23,7 +23,7 @@ from shepherd_core.data_models.experiment.observer_features import GpioActuation
 from shepherd_core.data_models.experiment.observer_features import GpioTracing
 from shepherd_core.data_models.experiment.observer_features import PowerTracing
 from shepherd_core.data_models.experiment.observer_features import SystemLogging
-from shepherd_core.data_models.experiment.observer_features import UartTracing
+from shepherd_core.data_models.experiment.observer_features import UartLogging
 from shepherd_core.data_models.testbed import Testbed
 from shepherd_core.data_models.testbed.cape import TargetPort
 from shepherd_core.logger import logger
@@ -91,7 +91,7 @@ class EmulationTask(ShpModel):
 
     power_tracing: Optional[PowerTracing] = PowerTracing()
     gpio_tracing: Optional[GpioTracing] = GpioTracing()
-    uart_tracing: Optional[UartTracing] = UartTracing()
+    uart_logging: Optional[UartLogging] = UartLogging()
     gpio_actuation: Optional[GpioActuation] = None
     sys_logging: Optional[SystemLogging] = SystemLogging()
 
@@ -132,7 +132,7 @@ class EmulationTask(ShpModel):
             raise ValueError("GPIO Actuation not yet implemented!")
 
         io_requested = any(
-            _io is not None for _io in (self.gpio_actuation, self.gpio_tracing, self.uart_tracing)
+            _io is not None for _io in (self.gpio_actuation, self.gpio_tracing, self.uart_logging)
         )
         if self.enable_io and not io_requested:
             logger.warning("Target IO enabled, but no feature requested IO")
@@ -147,7 +147,7 @@ class EmulationTask(ShpModel):
         tgt_cfg = xp.get_target_config(tgt_id)
         io_requested = any(
             _io is not None
-            for _io in (tgt_cfg.gpio_actuation, tgt_cfg.gpio_tracing, tgt_cfg.uart_tracing)
+            for _io in (tgt_cfg.gpio_actuation, tgt_cfg.gpio_tracing, tgt_cfg.uart_logging)
         )
 
         return cls(
@@ -162,7 +162,7 @@ class EmulationTask(ShpModel):
             virtual_source=tgt_cfg.virtual_source,
             power_tracing=tgt_cfg.power_tracing,
             gpio_tracing=tgt_cfg.gpio_tracing,
-            uart_tracing=tgt_cfg.uart_tracing,
+            uart_logging=tgt_cfg.uart_logging,
             gpio_actuation=tgt_cfg.gpio_actuation,
             sys_logging=xp.sys_logging,
         )

--- a/shepherd_core/shepherd_core/data_models/task/harvest.py
+++ b/shepherd_core/shepherd_core/data_models/task/harvest.py
@@ -9,6 +9,7 @@ from typing import Optional
 from pydantic import Field
 from pydantic import model_validator
 from typing_extensions import Self
+from typing_extensions import deprecated
 
 from shepherd_core.data_models.base.shepherd import ShpModel
 from shepherd_core.data_models.base.timezone import local_tz
@@ -37,7 +38,7 @@ class HarvestTask(ShpModel):
     # timestamp or unix epoch time, None = ASAP
     duration: Optional[timedelta] = None
     # ⤷ Duration of recording in seconds, None = till EOFSys
-    abort_on_error: bool = False
+    abort_on_error: Annotated[bool, deprecated("has no effect")] = False
 
     # emulation-specific
     use_cal_default: bool = False

--- a/shepherd_core/shepherd_core/data_models/task/harvest.py
+++ b/shepherd_core/shepherd_core/data_models/task/harvest.py
@@ -36,7 +36,7 @@ class HarvestTask(ShpModel):
     time_start: Optional[datetime] = None
     # timestamp or unix epoch time, None = ASAP
     duration: Optional[timedelta] = None
-    # ⤷ Duration of recording in seconds, None = till EOF
+    # ⤷ Duration of recording in seconds, None = till EOFSys
     abort_on_error: bool = False
 
     # emulation-specific

--- a/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
+++ b/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
@@ -91,8 +91,8 @@ class ObserverTasks(ShpModel):
             tasks.append(task)
         return tasks
 
-    def get_output_paths(self) -> dict:
-        values = {}
+    def get_output_paths(self) -> dict[str, Path]:
+        values: dict[str, Path] = {}
         if isinstance(self.emulation, EmulationTask):
             if self.emulation.output_path is None:
                 raise ValueError("Emu-Task should have a valid output-path")

--- a/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
+++ b/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
@@ -3,10 +3,12 @@
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
+from typing import Annotated
 from typing import Optional
 
 from pydantic import validate_call
 from typing_extensions import Self
+from typing_extensions import deprecated
 
 from shepherd_core.data_models.base.content import IdInt
 from shepherd_core.data_models.base.content import NameStr
@@ -28,7 +30,7 @@ class ObserverTasks(ShpModel):
     # PRE PROCESS
     time_prep: datetime  # TODO: should be optional
     root_path: Path
-    abort_on_error: bool
+    abort_on_error: Annotated[bool, deprecated("has no effect")]
 
     # fw mod, store as hex-file and program
     fw1_mod: Optional[FirmwareModTask] = None

--- a/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
+++ b/shepherd_core/shepherd_core/data_models/task/observer_tasks.py
@@ -30,7 +30,7 @@ class ObserverTasks(ShpModel):
     # PRE PROCESS
     time_prep: datetime  # TODO: should be optional
     root_path: Path
-    abort_on_error: Annotated[bool, deprecated("has no effect")]
+    abort_on_error: Annotated[bool, deprecated("has no effect")] = False
 
     # fw mod, store as hex-file and program
     fw1_mod: Optional[FirmwareModTask] = None
@@ -72,7 +72,6 @@ class ObserverTasks(ShpModel):
             owner_id=xp.owner_id,
             time_prep=t_start - tb.prep_duration,
             root_path=root_path,
-            abort_on_error=xp.abort_on_error,
             fw1_mod=FirmwareModTask.from_xp(xp, tb, tgt_id, 1, fw_paths[0]),
             fw2_mod=FirmwareModTask.from_xp(xp, tb, tgt_id, 2, fw_paths[1]),
             fw1_prog=ProgrammingTask.from_xp(xp, tb, tgt_id, 1, fw_paths[0]),

--- a/shepherd_core/shepherd_core/data_models/task/programming.py
+++ b/shepherd_core/shepherd_core/data_models/task/programming.py
@@ -33,6 +33,7 @@ class ProgrammingTask(ShpModel):
     voltage: Annotated[float, Field(ge=1, lt=5)] = 3
     datarate: Annotated[int, Field(gt=0, le=1_000_000)] = 200_000
     protocol: ProgrammerProtocol
+    # TODO: eradicate - should not exist. derive protocol from mcu_type
 
     simulate: bool = False
 

--- a/shepherd_core/shepherd_core/data_models/task/testbed_tasks.py
+++ b/shepherd_core/shepherd_core/data_models/task/testbed_tasks.py
@@ -1,5 +1,6 @@
 """Collection of tasks for all observers included in experiment."""
 
+from pathlib import Path
 from typing import Annotated
 from typing import Optional
 
@@ -50,11 +51,11 @@ class TestbedTasks(ShpModel):
                 return tasks
         return None
 
-    def get_output_paths(self) -> dict:
+    def get_output_paths(self) -> dict[str, Path]:
         # TODO: computed field preferred, but they don't work here, as
         #  - they are always stored in yaml despite "repr=False"
         #  - solution will shift to some kind of "result"-datatype that is combinable
-        values = {}
+        values: dict[str, Path] = {}
         for obt in self.observer_tasks:
             values = {**values, **obt.get_output_paths()}
         return values

--- a/shepherd_core/shepherd_core/data_models/testbed/cape_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/testbed/cape_fixture.yaml
@@ -92,3 +92,11 @@
     id: 1270065
     name: cape65
     comment: only 220u/440uF on 5V
+- datatype: cape
+  parameters:
+    id: 42000
+    name: unit_testing_cape
+    version: none
+    description: for unit testing
+    created: 2025-04-29
+    calibrated: 2025-04-29

--- a/shepherd_core/shepherd_core/data_models/testbed/gpio.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/gpio.py
@@ -65,3 +65,10 @@ class GPIO(ShpModel, title="GPIO of Observer Node"):
 
     def user_controllable(self) -> bool:
         return ("gpio" in self.name.lower()) and (self.direction in {"IO", "OUT"})
+
+    def user_recordable(self) -> bool:
+        return (
+            ("gpio" in self.name.lower())
+            and (self.direction in {"IO", "IN"})
+            and (self.pin_pru is not None)
+        )

--- a/shepherd_core/shepherd_core/data_models/testbed/observer_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/testbed/observer_fixture.yaml
@@ -221,3 +221,20 @@
     target_a:
       name: nRF52_FRAM_1392_390
     created: 2023-09-22 12:12:12
+- datatype: observer
+  parameters:
+    id: 42
+    name: unit_testing_sheep
+    ip: 0.0.0.0
+    mac: 00:00:00:00:00:00
+    room: none
+    eth_port: none
+    description: unit testing
+    longitude: 0
+    latitude: 0
+    cape:
+      name: unit_testing_cape
+    target_a:
+      name: unit_testing_target
+    created: 2025-04-29 13:07:00
+    active: true

--- a/shepherd_core/shepherd_core/data_models/testbed/target_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/testbed/target_fixture.yaml
@@ -161,3 +161,16 @@
       name: nRF52
     mcu2: null
     created: 2022-12-12 12:12:12
+
+- datatype: target
+  parameters:
+    id: 42
+    name: unit_testing_target
+    version: v0
+    description: for unit testing
+    comment: no comment
+    created: 2025-04-29
+    mcu1:
+      name: nRF52
+    mcu2:
+      name: MSP430FR

--- a/shepherd_core/shepherd_core/data_models/testbed/testbed_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/testbed/testbed_fixture.yaml
@@ -23,3 +23,14 @@
       - name: sheep12
       - name: sheep13
       - name: sheep14
+
+- datatype: testbed
+  parameters:
+    id: 42
+    name: unit_testing_testbed
+    description: "Artificial Testbed used in unit testing"
+    shared_storage: true
+    data_on_server: /tmp/
+    data_on_observer: /tmp/
+    observers:
+      - name: unit_testing_sheep

--- a/shepherd_core/shepherd_core/reader.py
+++ b/shepherd_core/shepherd_core/reader.py
@@ -412,19 +412,20 @@ class Reader:
                 self.file_path.name,
             )
         # same length of datasets:
-        for dset in ["current", "time"]:
+        samples_n = self.h5file["data"]["time"].shape[0]
+        for dset in ["voltage", "current"]:
             ds_size = self.h5file["data"][dset].shape[0]
-            if ds_size != self.samples_n:
+            if ds_size != samples_n:
                 self._logger.warning(
                     "[FileValidation] dataset '%s' has different size (=%d), "
-                    "compared to smallest set (=%d), in '%s'",
+                    "compared to time (=%d), in '%s'",
                     dset,
                     ds_size,
-                    self.samples_n,
+                    samples_n,
                     self.file_path.name,
                 )
         # dataset-length should be multiple of chunk-size
-        remaining_size = self.samples_n % self.CHUNK_SAMPLES_N
+        remaining_size = samples_n % self.CHUNK_SAMPLES_N
         if remaining_size != 0:
             self._logger.warning(
                 "[FileValidation] datasets are not aligned with chunk-size in '%s'",

--- a/shepherd_core/shepherd_core/testbed_client/fixtures.py
+++ b/shepherd_core/shepherd_core/testbed_client/fixtures.py
@@ -57,6 +57,7 @@ class Fixture:
         self._iter_list = list(self.elements_by_name.values())
 
     def __getitem__(self, key: Union[str, int]) -> dict:
+        original_key = key
         if isinstance(key, str):
             key = key.lower()
             if key in self.elements_by_name:
@@ -65,7 +66,7 @@ class Fixture:
                 key = int(key)
         if key in self.elements_by_id:
             return self.elements_by_id[int(key)]
-        msg = f"{self.model_type} '{key}' not found!"
+        msg = f"{self.model_type} '{original_key}' not found!"
         raise ValueError(msg)
 
     def __iter__(self) -> Self:

--- a/shepherd_core/shepherd_core/testbed_client/fixtures.py
+++ b/shepherd_core/shepherd_core/testbed_client/fixtures.py
@@ -2,6 +2,7 @@
 
 import copy
 import pickle
+from collections.abc import Iterable
 from collections.abc import Mapping
 from datetime import datetime
 from datetime import timedelta
@@ -34,11 +35,11 @@ class Fixture:
 
     def __init__(self, model_type: str) -> None:
         self.model_type: str = model_type.lower()
-        self.elements_by_name: dict[str, dict] = {}
-        self.elements_by_id: dict[int, dict] = {}
+        self.elements_by_name: dict[str, dict[str, Any]] = {}
+        self.elements_by_id: dict[int, dict[str, Any]] = {}
         # Iterator reset
         self._iter_index: int = 0
-        self._iter_list: list = list(self.elements_by_name.values())
+        self._iter_list: list[dict[str, Any]] = list(self.elements_by_name.values())
 
     def insert(self, data: Wrapper) -> None:
         # ⤷ TODO: could get easier
@@ -54,9 +55,9 @@ class Fixture:
         self.elements_by_name[name] = data_model
         self.elements_by_id[_id] = data_model
         # update iterator
-        self._iter_list = list(self.elements_by_name.values())
+        self._iter_list: list[dict[str, Any]] = list(self.elements_by_name.values())
 
-    def __getitem__(self, key: Union[str, int]) -> dict:
+    def __getitem__(self, key: Union[str, int]) -> dict[str, Any]:
         original_key = key
         if isinstance(key, str):
             key = key.lower()
@@ -74,14 +75,14 @@ class Fixture:
         self._iter_list = list(self.elements_by_name.values())
         return self
 
-    def __next__(self) -> Any:
+    def __next__(self) -> dict[str, Any]:
         if self._iter_index < len(self._iter_list):
             member = self._iter_list[self._iter_index]
             self._iter_index += 1
             return member
         raise StopIteration
 
-    def keys(self):  # noqa: ANN201
+    def keys(self) -> Iterable[str]:
         return self.elements_by_name.keys()
 
     def refs(self) -> dict:
@@ -150,13 +151,13 @@ class Fixture:
             base[key] = value
         return base
 
-    def query_id(self, _id: int) -> dict:
+    def query_id(self, _id: int) -> dict[str, Any]:
         if isinstance(_id, int) and _id in self.elements_by_id:
             return self.elements_by_id[_id]
         msg = f"Initialization of {self.model_type} by ID failed - {_id} is unknown!"
         raise ValueError(msg)
 
-    def query_name(self, name: str) -> dict:
+    def query_name(self, name: str) -> dict[str, Any]:
         if isinstance(name, str) and name.lower() in self.elements_by_name:
             return self.elements_by_name[name.lower()]
         msg = f"Initialization of {self.model_type} by name failed - {name} is unknown!"
@@ -240,7 +241,7 @@ class Fixtures:
         msg = f"Component '{key}' not found!"
         raise ValueError(msg)
 
-    def keys(self):  # noqa: ANN201
+    def keys(self) -> Iterable[str]:
         return self.components.keys()
 
     @staticmethod

--- a/shepherd_core/shepherd_core/testbed_client/user_model.py
+++ b/shepherd_core/shepherd_core/testbed_client/user_model.py
@@ -5,10 +5,7 @@ from hashlib import pbkdf2_hmac
 from typing import Annotated
 from typing import Any
 from typing import Optional
-from typing import Union
-from uuid import uuid4
 
-from pydantic import UUID4
 from pydantic import EmailStr
 from pydantic import Field
 from pydantic import SecretBytes
@@ -19,6 +16,7 @@ from pydantic import validate_call
 
 from shepherd_core.data_models.base.content import NameStr
 from shepherd_core.data_models.base.content import SafeStr
+from shepherd_core.data_models.base.content import id_default
 from shepherd_core.data_models.base.shepherd import ShpModel
 
 
@@ -41,10 +39,9 @@ def hash_password(pw: Annotated[str, StringConstraints(min_length=20, max_length
 class User(ShpModel):
     """meta-data representation of a testbed-component (physical object)."""
 
-    # id: UUID4 = Field(  # TODO: db-migration - temp fix for documentation
-    id: Union[UUID4, int] = Field(
+    id: int = Field(
         description="Unique ID",
-        default_factory=uuid4,
+        default_factory=id_default,
     )
     name: NameStr
     description: Optional[SafeStr] = None

--- a/shepherd_core/shepherd_core/version.py
+++ b/shepherd_core/shepherd_core/version.py
@@ -1,3 +1,3 @@
 """Separated string avoids circular imports."""
 
-version: str = "2025.05.2"
+version: str = "2025.05.3"

--- a/shepherd_core/tests/data_models/example_config_emulator.yaml
+++ b/shepherd_core/tests/data_models/example_config_emulator.yaml
@@ -33,7 +33,7 @@ parameters:
     V_output_mV: 3000
 
   power_tracing: null
-  uart_tracing:
+  uart_logging:
     baudrate: 9600
   sys_logging:
     kernel: true

--- a/shepherd_core/tests/data_models/test_task_models.py
+++ b/shepherd_core/tests/data_models/test_task_models.py
@@ -106,7 +106,6 @@ def test_task_model_observer_min1() -> None:
         owner_id=666,
         time_prep="2044-01-01 12:13:14",
         root_path="/usr",
-        abort_on_error=False,
     )
 
 

--- a/shepherd_data/pyproject.toml
+++ b/shepherd_data/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pandas>=2.0.0",  # full-version, v2 is OK
     "pyYAML",
     "scipy",   # full-version
-    "shepherd-core[inventory]>=2025.05.2",  # libs are strongly coupled
+    "shepherd-core[inventory]>=2025.05.3",  # libs are strongly coupled
     "tqdm",    # full-version
 ]
 

--- a/shepherd_data/shepherd_data/__init__.py
+++ b/shepherd_data/shepherd_data/__init__.py
@@ -11,7 +11,7 @@ from shepherd_core import Writer
 
 from .reader import Reader
 
-__version__ = "2025.05.2"
+__version__ = "2025.05.3"
 
 __all__ = [
     "Reader",


### PR DESCRIPTION
## v2025.05.3

- fix naming of `UartTracer` in favor of separate `UartLogger` (**breaking change, required for sheep v0.9.0**)
- `UartLogger` allows setting baudrate, parity, stopbits, bytesize
- `GPIOTracer` can now be used to mask off unwanted pins
  - `.gpio` receives a list of int that corresponds with GPIO-number of TargetPort (new 2025 edge connector)
- change ID generation for compat with WebAPI
- allow publishing to PyPI by dispatch
- add separate mock testbed into fixtures (will be replaced soon, by testbed-client)
- deprecate `.abort_on_error`
- detailed doc for harvester config