### PR TITLE
Gui & only warn for extra fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v2026.5.1 unreleased
 
+- additional model parameters are now ignored instead of forbidden
+  - a dedicated root-validator is warning about them though
+  - avoiding exceptions should be more user-friendly as it won't raise exceptions
+  - this should help with
 - make `.model_dump()` more yaml-friendly with less special types
 - TestbedClient
   - add `.is_connected()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - additional model parameters are now ignored instead of forbidden
   - a dedicated root-validator is warning about them though
   - avoiding exceptions should be more user-friendly as it won't raise exceptions
-  - this should help with
+  - this should help with longterm compat between versions
+  - old behavior can be activated with `raise_for_extra_fields()`
+- add `--show-gui`/`-g` to data-CLI to show a pyplot-GUI (allows zooming)
 - make `.model_dump()` more yaml-friendly with less special types
 - TestbedClient
   - add `.is_connected()`

--- a/shepherd_core/shepherd_core/data_models/base/shepherd.py
+++ b/shepherd_core/shepherd_core/data_models/base/shepherd.py
@@ -10,7 +10,10 @@ from typing import final
 import ryaml
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import model_validator
 from typing_extensions import Self
+
+from shepherd_core.logger import log
 
 from .timezone import local_now
 from .wrapper import Wrapper
@@ -49,7 +52,7 @@ class ShpModel(BaseModel):
 
     model_config = ConfigDict(
         frozen=True,  # -> const after creation, hashable! but currently manually with .get_hash()
-        extra="forbid",  # no unnamed attributes allowed
+        extra="ignore",  # additional parameters get ignored (validator below is warning about them)
         validate_default=True,
         validate_assignment=True,  # not relevant for the frozen model
         str_min_length=1,  # force more meaningful descriptors,
@@ -98,6 +101,18 @@ class ShpModel(BaseModel):
         """Fn of dict."""
         for key in self.keys():
             yield key, self.__getattribute__(key)
+
+    @model_validator(mode="before")
+    @classmethod
+    def __alert_extra_field__(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if isinstance(values, dict) and (
+            extra_fields := values.keys()
+            - cls.model_fields.keys()
+            - {v.alias for v in cls.model_fields.values()}
+        ):
+            log.warning("%s is ignoring extra fields: %s", cls.__name__, extra_fields)
+
+        return values
 
     @final
     @classmethod

--- a/shepherd_core/shepherd_core/data_models/base/shepherd.py
+++ b/shepherd_core/shepherd_core/data_models/base/shepherd.py
@@ -18,6 +18,17 @@ from shepherd_core.logger import log
 from .timezone import local_now
 from .wrapper import Wrapper
 
+only_warn_extra_fields: bool = True
+
+
+def raise_for_extra_fields() -> None:
+    """Instead of warning, raise an exception without mercy.
+
+    This is useful for the web-server
+    """
+    global only_warn_extra_fields  # noqa: PLW0603
+    only_warn_extra_fields = False
+
 
 def path_to_str(old: dict) -> dict:
     r"""Allow platform-independent pickling of ShpModel.
@@ -52,7 +63,8 @@ class ShpModel(BaseModel):
 
     model_config = ConfigDict(
         frozen=True,  # -> const after creation, hashable! but currently manually with .get_hash()
-        extra="ignore",  # additional parameters get ignored (validator below is warning about them)
+        extra="ignore",
+        # ⤷ additional parameters get ignored (validator below is warning about them)
         validate_default=True,
         validate_assignment=True,  # not relevant for the frozen model
         str_min_length=1,  # force more meaningful descriptors,
@@ -110,7 +122,11 @@ class ShpModel(BaseModel):
             - cls.model_fields.keys()
             - {v.alias for v in cls.model_fields.values()}
         ):
-            log.warning("%s is ignoring extra fields: %s", cls.__name__, extra_fields)
+            if only_warn_extra_fields:
+                log.warning("%s is ignoring extra fields: %s", cls.__name__, extra_fields)
+            else:
+                msg = f"{cls.__name__} contains extra fields: {extra_fields}"
+                raise ValueError(msg)
 
         return values
 

--- a/shepherd_core/tests/data_models/test_experiment_models.py
+++ b/shepherd_core/tests/data_models/test_experiment_models.py
@@ -214,6 +214,7 @@ def test_experiment_model_gpiotracing_min() -> None:
     GpioTracing()
 
 
+@pytest.mark.xfail  # extra fields are now ignored
 def test_experiment_model_gpiotracing_fault_mask() -> None:
     with pytest.raises(ValidationError):
         GpioTracing(mask=0)

--- a/shepherd_core/tests/data_models/test_experiment_models.py
+++ b/shepherd_core/tests/data_models/test_experiment_models.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from datetime import timedelta
 
 import pytest
+from shepherd_core.data_models.base.shepherd import raise_for_extra_fields
 from pydantic import ValidationError
 from shepherd_core.config import core_config
 from shepherd_core.data_models.base.timezone import local_now
@@ -216,6 +217,13 @@ def test_experiment_model_gpiotracing_min() -> None:
 
 @pytest.mark.xfail  # extra fields are now ignored
 def test_experiment_model_gpiotracing_fault_mask() -> None:
+    with pytest.raises(ValidationError):
+        GpioTracing(mask=0)
+
+
+def test_experiment_model_gpiotracing_fault_mask_raise() -> None:
+    # extra fields are now ignored by default - so reactivate raise-mode
+    raise_for_extra_fields()
     with pytest.raises(ValidationError):
         GpioTracing(mask=0)
 

--- a/shepherd_core/tests/data_models/test_experiment_models.py
+++ b/shepherd_core/tests/data_models/test_experiment_models.py
@@ -3,9 +3,9 @@ from collections.abc import Generator
 from datetime import timedelta
 
 import pytest
-from shepherd_core.data_models.base.shepherd import raise_for_extra_fields
 from pydantic import ValidationError
 from shepherd_core.config import core_config
+from shepherd_core.data_models.base.shepherd import raise_for_extra_fields
 from shepherd_core.data_models.base.timezone import local_now
 from shepherd_core.data_models.content import EnergyEnvironment
 from shepherd_core.data_models.content import EnergyProfile

--- a/shepherd_data/shepherd_data/cli.py
+++ b/shepherd_data/shepherd_data/cli.py
@@ -432,6 +432,12 @@ def downsample(
     is_flag=True,
     help="Also consider files in sub-folders",
 )
+@click.option(
+    "--show-gui",
+    "-g",
+    is_flag=True,
+    help="Open PyPlot-Window, which allows basic zoom & pan (in addition to plotting to file).",
+)
 # TODO: allow SVG-output
 # TODO: allow opt-harvest iv-samples
 def plot(
@@ -444,6 +450,7 @@ def plot(
     multiplot: bool,
     only_power: bool,
     recurse: bool = False,
+    show_gui: bool = False,
 ) -> None:
     """Plot IV-trace from file or directory containing shepherd-recordings."""
     files = path_to_flist(in_data, recurse=recurse)
@@ -460,12 +467,16 @@ def plot(
                         continue
                     data.append(date)
                 else:
-                    shpr.plot_to_file(start, end, width, height, only_pwr=only_power)
+                    shpr.plot_to_file(
+                        start, end, width, height, only_pwr=only_power, show_gui=show_gui
+                    )
         except TypeError:
             logger.exception("ERROR: Will skip file. It caused an exception.")
     if multiplot:
         logger.info("Got %d datasets to plot", len(data))
-        mpl_path = Reader.multiplot_to_file(data, in_data, width, height, only_pwr=only_power)
+        mpl_path = Reader.multiplot_to_file(
+            data, in_data, width, height, only_pwr=only_power, show_gui=show_gui
+        )
         if mpl_path:
             logger.info("Plot generated and saved to '%s'", mpl_path.name)
         else:

--- a/shepherd_data/shepherd_data/reader.py
+++ b/shepherd_data/shepherd_data/reader.py
@@ -598,7 +598,8 @@ class Reader(CoreReader):
         height: int = 10,
         *,
         only_pwr: bool = False,
-    ) -> None:
+        show_gui: bool = False,
+    ) -> Path | None:
         """Create (down-sampled) IV-Plots.
 
         Omitting start- and end-time will use the whole trace (full duration).
@@ -610,23 +611,27 @@ class Reader(CoreReader):
         :param only_pwr: plot power-trace instead of voltage, current & power
         """
         if not isinstance(self.file_path, Path):
-            return
+            return None
 
         data = self.generate_plot_data(start_s, end_s)
         if data is None:
-            return
+            return None
 
         start_str = f"{data['start_s']:.3f}".replace(".", "s")
         end_str = f"{data['end_s']:.3f}".replace(".", "s")
         plot_path = self.file_path.resolve().with_suffix(f".plot_{start_str}_to_{end_str}.png")
         if plot_path.exists():
             self._logger.warning("Plot exists, will skip & not overwrite!")
-            return
+            return None
         self._logger.info("Plot generated, will be saved to '%s'", plot_path.name)
         fig = self.assemble_plot(data, width, height, only_pwr=only_pwr)
         plt.savefig(plot_path)
+        if show_gui:  # opens pyplot-window
+            plt.ion()
+            plt.show(block=True)
         plt.close(fig)
         plt.clf()
+        return plot_path
 
     @staticmethod
     def multiplot_to_file(
@@ -636,6 +641,7 @@ class Reader(CoreReader):
         height: int = 10,
         *,
         only_pwr: bool = False,
+        show_gui: bool = False,
     ) -> Path | None:
         """Create (down-sampled) IV-Multi-Plots (of more than one trace).
 
@@ -656,6 +662,9 @@ class Reader(CoreReader):
             return None
         fig = Reader.assemble_plot(data, width, height, only_pwr=only_pwr)
         plt.savefig(plot_path)
+        if show_gui:  # opens pyplot-window
+            plt.ion()
+            plt.show(block=True)
         plt.close(fig)
         plt.clf()
         return plot_path


### PR DESCRIPTION
- additional model parameters are now ignored instead of forbidden
  - a dedicated root-validator is warning about them though
  - avoiding exceptions should be more user-friendly as it won't raise exceptions
  - this should help with longterm compat between versions
  - old behavior can be activated with `raise_for_extra_fields()`
- add `--show-gui`/`-g` to data-CLI to show a pyplot-GUI (allows zooming)